### PR TITLE
Fix CI test failures (unblocks all open PRs)

### DIFF
--- a/providers/sync/mdblist/_common.py
+++ b/providers/sync/mdblist/_common.py
@@ -16,7 +16,9 @@ STATE_DIR = Path("/config/.cw_state")
 WATERMARK_PATH = STATE_DIR / "mdblist.watermarks.json"
 START_OF_TIME_ISO = "1900-01-01T00:00:00Z"
 
-STATE_DIR.mkdir(parents=True, exist_ok=True)
+# STATE_DIR is created lazily on first write (see write_json / _migrate_legacy_json).
+# Don't mkdir at import time — it crashes when /config is absent or unwritable (e.g. CI),
+# and the other sync providers already defer directory creation the same way.
 
 
 def _pair_scope() -> str | None:

--- a/providers/sync/tmdb/_common.py
+++ b/providers/sync/tmdb/_common.py
@@ -13,7 +13,9 @@ from typing import Any, Mapping
 from cw_platform.id_map import canonical_key, ids_from, minimal as id_minimal
 
 STATE_DIR = Path("/config/.cw_state")
-STATE_DIR.mkdir(parents=True, exist_ok=True)
+# STATE_DIR is created lazily on first write (see write_json / _migrate_legacy_json).
+# Don't mkdir at import time — it crashes when /config is absent or unwritable (e.g. CI),
+# and the other sync providers already defer directory creation the same way.
 
 
 def _pair_scope() -> str | None:

--- a/tests/test_orchestrator_oneway_watchlist.py
+++ b/tests/test_orchestrator_oneway_watchlist.py
@@ -81,13 +81,16 @@ class FakeOps:
 def test_orchestrator_oneway_watchlist_add_then_observed_remove(
     config_base: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # SRC initially has A, B, C; DST has only A. With the default one-way
+    # remove_mode of "source_deletes", DST removals are driven by items observed
+    # to disappear from SRC (not by a plain DST-minus-SRC mirror diff).
     src_items = {
         "imdb:tt01": {"type": "movie", "title": "A", "year": 2000, "ids": {"imdb": "tt01"}},
+        "imdb:tt02": {"type": "movie", "title": "B", "year": 2001, "ids": {"imdb": "tt02"}},
         "imdb:tt03": {"type": "movie", "title": "C", "year": 2002, "ids": {"imdb": "tt03"}},
     }
     dst_items = {
         "imdb:tt01": {"type": "movie", "title": "A", "year": 2000, "ids": {"imdb": "tt01"}},
-        "imdb:tt02": {"type": "movie", "title": "B", "year": 2001, "ids": {"imdb": "tt02"}},
     }
 
     src = FakeOps("SRC", src_items)
@@ -134,13 +137,17 @@ def test_orchestrator_oneway_watchlist_add_then_observed_remove(
 
     orch = Orchestrator(cfg)
 
-    # Run 1: DST should receive missing C
+    # Run 1: DST should receive the missing B and C, and establishes the
+    # source baseline. No removals on the first run.
     orch.run()
     assert len(dst.add_calls) == 1
-    assert [it.get("ids", {}).get("imdb") for it in dst.add_calls[0]] == ["tt03"]
+    assert sorted(it.get("ids", {}).get("imdb") for it in dst.add_calls[0]) == ["tt02", "tt03"]
     assert dst.remove_calls == []
 
-    # Run 2: now DST has a baseline that includes B,  removal is allowed.
+    # B is deleted from SRC -> the next run should observe the deletion.
+    src.index.pop("imdb:tt02", None)
+
+    # Run 2: the observed source-side deletion of B propagates to DST.
     orch.run()
     assert len(dst.remove_calls) == 1
     assert [it.get("ids", {}).get("imdb") for it in dst.remove_calls[0]] == ["tt02"]

--- a/tests/test_standard_scheduling.py
+++ b/tests/test_standard_scheduling.py
@@ -9,7 +9,7 @@ def test_normalize_scheduling_clamps_custom_interval_to_minimum() -> None:
     cfg = {
         "scheduling": {
             "enabled": True,
-            "mode": "custom",
+            "mode": "custom_interval",
             "custom_interval_minutes": 5,
         }
     }


### PR DESCRIPTION
## Summary

The `test (3.11)` / `test (3.12)` checks fail on **all four open PRs** (#28, #33, #35, #36). The root cause has nothing to do with the Renovate dependency bumps — it's three latent failures inherited from upstream, all masked by `--maxfail=1` in `pytest.ini` (CI stopped at the first one, so the other two were never reported).

All three are fixed here. The full suite (`python -m pytest`) now passes: **133 passed**.

## Root causes & fixes

**1. Import-time `mkdir` crashes test collection (production fix)**
`providers/sync/mdblist/_common.py` and `providers/sync/tmdb/_common.py` called `STATE_DIR.mkdir(...)` on the hard-coded Docker path `/config/.cw_state` at *module import time*. Where `/config` is absent or unwritable (CI, local dev), importing the module raises `FileNotFoundError`/`PermissionError` and pytest collection aborts:

```
FileNotFoundError: '/config/.cw_state'  ->  PermissionError: '/config'
FAILED providers/tests/test_confirmed_keys.py::...[sync._mod_MDBLIST]
```

The directory is already created lazily on first write (`write_json` / `_migrate_legacy_json`), exactly as the other six sync providers (jellyfin, emby, plex, trakt, tautulli, simkl) do. The eager top-level `mkdir` is redundant — removed.

**2. Stale scheduling test (test-only)**
`test_normalize_scheduling_clamps_custom_interval_to_minimum` fed `mode: "custom"`, a legacy alias deliberately removed upstream in *"remove legacy migration code"*. Updated to the canonical `mode: "custom_interval"`. The test still verifies its real purpose — the 5 → 15 minute clamp.

**3. Stale one-way watchlist test (test-only)**
`test_orchestrator_oneway_watchlist_add_then_observed_remove` asserted mirror-style removal (everything in DST but not SRC), but one-way sync now defaults to `remove_mode: "source_deletes"` (mirror is opt-in / destructive). Rewritten to exercise the actual observed-source-delete path — an item present in SRC, synced to DST, then deleted from SRC and propagated as a removal — matching the test's name.

## Notes

- Fixes #1 (production) and #2/#3 (test-only) are split into two commits.
- All three issues are present on `upstream/main` as well (the orchestrator code and both tests are byte-identical to upstream); upstream's CI also masks them via `--maxfail=1`.
- Merging this unblocks the `test` check on all four open Renovate PRs.

## Test plan
- [x] `python -m pytest` (CI-equivalent, `--maxfail=1`) → 133 passed
- [x] Full suite without `maxfail` → 133 passed