### PR TITLE
ci: run tests on renovate/** branches for branch-automerge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # main = post-merge run. renovate/** lets Renovate's branch-automerge updates
+    # (which never open a PR) run `test` on the branch, so the default-branch
+    # ruleset (required `test (3.14)` check, pull_request rule dropped) can
+    # fast-forward main once the branch is green.
+    branches: [main, 'renovate/**']
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Why
Renovate's branch-automerge dependency updates never open a PR, so this repo's `test` check (PR/main-only) never ran on them — the no-PR `renovate/**` branch's combined status stayed empty and stalled `:automergeRequireAllStatusChecks`, so updates fell back to PRs.

## What
Add `renovate/**` to the `push` trigger so CI runs on the branch. Once green, the default-branch ruleset (required `test` check, `pull_request` rule dropped in the homelab terraform PR) can fast-forward `main` with no PR.

**Merge this before** the ruleset change that drops the PR rule for this repo (homelab PR jabrown93/homelab#1598), otherwise the no-PR branch would have no check and stall.