### PR TITLE
Harden app-auth setup flow and revoke mobile devices on session clear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ playwright/.auth/
 # CrossWatch runtime state
 .cw_state/
 .cw_master_key
+.setup_token
 
 # Local test/temp workspaces
 .pytest_tmp*/

--- a/api/appAuthAPI.py
+++ b/api/appAuthAPI.py
@@ -18,7 +18,8 @@ from urllib.parse import urlsplit
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
-from cw_platform.config_base import load_config, save_config, setup_token_file
+from cw_platform.config_base import load_config, save_config, setup_token_file, write_setup_token
+from _logging import log
 
 __all__ = [
     "router",
@@ -499,16 +500,22 @@ def _clear_sessions(cfg: dict[str, Any]) -> None:
     if isinstance(a, dict):
         a["sessions"] = []
         _sync_legacy_session(a, [])
-    # Revoke paired mobile devices too, so a device paired during a compromise
-    # can't outlive the credential rotation meant to evict it. Deferred import:
-    # api.mobileAPI imports this module at load time, so a top-level import here
-    # would be circular.
+
+
+def _revoke_mobile_devices(cfg: dict[str, Any]) -> None:
+    """Revoke every paired mobile device, so a device paired during a compromise
+    can't outlive the credential rotation meant to evict it. Called only from the
+    security-sensitive session-clearing paths (password change, disable-auth,
+    logout-all, apply-now) -- not from every credentials save, since that would
+    also fire on benign settings tweaks (e.g. remember-session preference).
+    Deferred import: api.mobileAPI imports this module at load time, so a
+    top-level import here would be circular."""
     try:
         from api.mobileAPI import revoke_all_devices
 
         revoke_all_devices(cfg)
-    except Exception:
-        pass
+    except Exception as exc:
+        log.error("Failed to revoke paired mobile devices during a session-clearing event", exc)
 
 
 def _clear_other_sessions(cfg: dict[str, Any], token: str | None) -> None:
@@ -1146,6 +1153,7 @@ def api_logout_all(request: Request) -> JSONResponse:
         if not _origin_allowed(request):
             return _origin_blocked_response()
     _clear_sessions(cfg)
+    _revoke_mobile_devices(cfg)
     save_config(cfg)
     resp = JSONResponse({"ok": True}, headers={"Cache-Control": "no-store"})
     _del_cookie(resp, request)
@@ -1177,6 +1185,7 @@ def api_apply_now(request: Request, payload: dict[str, Any] | None = Body(None))
         return _origin_blocked_response()
 
     _clear_sessions(cfg)
+    _revoke_mobile_devices(cfg)
     save_config(cfg)
 
     def _kill() -> None:
@@ -1238,9 +1247,17 @@ def api_set_credentials(request: Request, payload: dict[str, Any] = Body(...)) -
         a["reset_required"] = False
         a["username"] = username or str(a.get("username") or "")
         _clear_sessions(cfg)
+        _revoke_mobile_devices(cfg)
         save_config(cfg)
-        if was_setup_locked:
-            _consume_setup_token()
+        # Disabling auth makes setup_lock_required(cfg) true again (auth_required
+        # flips to False), so this endpoint is now pre-auth-reachable once more.
+        # Mint a fresh token unconditionally -- otherwise, once the token that
+        # gated this very request is consumed, nothing could ever re-lock this
+        # instance down again short of restarting the process.
+        fresh_token = secrets.token_urlsafe(24)
+        write_setup_token(fresh_token)
+        print(f"[AUTH] App authentication disabled. New one-time setup token: {fresh_token}")
+        print(f"[AUTH] Provide this token as \"setup_token\" in POST /api/app-auth/credentials, or read it from {setup_token_file()}.")
         resp = JSONResponse({"ok": True, "enabled": False}, headers={"Cache-Control": "no-store"})
         _del_cookie(resp, req)
         return resp
@@ -1278,6 +1295,8 @@ def api_set_credentials(request: Request, payload: dict[str, Any] = Body(...)) -
     a["username"] = username
     a["reset_required"] = False
     _clear_sessions(cfg)
+    if password:
+        _revoke_mobile_devices(cfg)
     _clear_setup_autogen_flag(cfg)
     _mark_upgrade_pending_if_needed(cfg)
 

--- a/api/appAuthAPI.py
+++ b/api/appAuthAPI.py
@@ -18,7 +18,7 @@ from urllib.parse import urlsplit
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
-from cw_platform.config_base import load_config, save_config
+from cw_platform.config_base import load_config, save_config, setup_token_file
 
 __all__ = [
     "router",
@@ -30,6 +30,7 @@ __all__ = [
     "is_authenticated",
     "reset_pending",
     "setup_lock_required",
+    "verify_setup_token",
     "register_app_auth",
 ]
 
@@ -324,6 +325,27 @@ def setup_lock_required(cfg: dict[str, Any]) -> bool:
     return not auth_required(cfg)
 
 
+def verify_setup_token(candidate: str) -> bool:
+    try:
+        p = setup_token_file()
+        expected = p.read_text(encoding="utf-8").strip() if p.exists() else ""
+    except Exception:
+        expected = ""
+    if not expected:
+        return False
+    got = str(candidate or "").strip()
+    if not got:
+        return False
+    return hmac.compare_digest(expected, got)
+
+
+def _consume_setup_token() -> None:
+    try:
+        setup_token_file().unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
 def _find_session(a: dict[str, Any], token: str | None) -> dict[str, Any] | None:
     t = (token or "").strip()
     if not t:
@@ -474,10 +496,19 @@ def _drop_session(cfg: dict[str, Any], token: str | None) -> None:
 
 def _clear_sessions(cfg: dict[str, Any]) -> None:
     a = cfg.get("app_auth")
-    if not isinstance(a, dict):
-        return
-    a["sessions"] = []
-    _sync_legacy_session(a, [])
+    if isinstance(a, dict):
+        a["sessions"] = []
+        _sync_legacy_session(a, [])
+    # Revoke paired mobile devices too, so a device paired during a compromise
+    # can't outlive the credential rotation meant to evict it. Deferred import:
+    # api.mobileAPI imports this module at load time, so a top-level import here
+    # would be circular.
+    try:
+        from api.mobileAPI import revoke_all_devices
+
+        revoke_all_devices(cfg)
+    except Exception:
+        pass
 
 
 def _clear_other_sessions(cfg: dict[str, Any], token: str | None) -> None:
@@ -1165,8 +1196,18 @@ def api_set_credentials(request: Request, payload: dict[str, Any] = Body(...)) -
     configured0 = auth_required(cfg)
     recovery_mode = reset_pending(cfg)
     token = req.cookies.get(COOKIE_NAME)
+    was_setup_locked = setup_lock_required(cfg)
 
-    if configured0 and not recovery_mode and not is_authenticated(cfg, token):
+    if was_setup_locked:
+        if not verify_setup_token(str(payload.get("setup_token") or "")):
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": "Invalid or missing setup token. Check the boot logs or the .setup_token file under your config directory.",
+                },
+                status_code=401,
+            )
+    elif not is_authenticated(cfg, token):
         return JSONResponse({"ok": False, "error": "Unauthorized"}, status_code=401)
     if configured0 and token and not _origin_allowed(req):
         return _origin_blocked_response()
@@ -1198,6 +1239,8 @@ def api_set_credentials(request: Request, payload: dict[str, Any] = Body(...)) -
         a["username"] = username or str(a.get("username") or "")
         _clear_sessions(cfg)
         save_config(cfg)
+        if was_setup_locked:
+            _consume_setup_token()
         resp = JSONResponse({"ok": True, "enabled": False}, headers={"Cache-Control": "no-store"})
         _del_cookie(resp, req)
         return resp
@@ -1240,6 +1283,8 @@ def api_set_credentials(request: Request, payload: dict[str, Any] = Body(...)) -
 
     token2, exp2 = _issue_session(cfg, req)
     save_config(cfg)
+    if was_setup_locked:
+        _consume_setup_token()
 
     resp = JSONResponse({"ok": True, "enabled": True, "expires_at": exp2}, headers={"Cache-Control": "no-store"})
     _set_cookie(resp, token2, exp2, req, persistent=_cfg_remember_session_enabled(a))

--- a/api/mobileAPI.py
+++ b/api/mobileAPI.py
@@ -67,6 +67,20 @@ def _cfg_mobile(cfg: dict[str, Any]) -> dict[str, Any]:
     return block
 
 
+def revoke_all_devices(cfg: dict[str, Any]) -> None:
+    """Revoke every paired mobile device. Called whenever app_auth sessions are
+    cleared (password change, disable-auth, logout-all, apply-now) so a device
+    paired during a compromise can't outlive the credential rotation meant to
+    evict it."""
+    block = _cfg_mobile(cfg)
+    devices_raw = block.get("devices")
+    devices = devices_raw if isinstance(devices_raw, list) else []
+    now = _now()
+    for device in devices:
+        if isinstance(device, dict) and not int(device.get("revoked_at") or 0):
+            device["revoked_at"] = now
+
+
 def _clean_scopes(values: Any) -> list[str]:
     raw = values if isinstance(values, list) else DEFAULT_SCOPES
     out: list[str] = []

--- a/assets/js/modals/core/app-auth-setup.js
+++ b/assets/js/modals/core/app-auth-setup.js
@@ -66,9 +66,11 @@ export function syncAppAuthState(root, state) {
   const usernameEl = root.querySelector('[data-field="username"]');
   const passwordEl = root.querySelector('[data-field="password"]');
   const password2El = root.querySelector('[data-field="password2"]');
+  const setupTokenEl = root.querySelector('[data-field="setup_token"]');
   if (usernameEl) state.username = usernameEl.value;
   if (passwordEl) state.password = passwordEl.value;
   if (password2El) state.password2 = password2El.value;
+  if (setupTokenEl) state.setup_token = setupTokenEl.value;
   return state;
 }
 
@@ -77,6 +79,7 @@ export function validateAppAuthState(state) {
   if (!String(state?.password || "")) return "Password is required.";
   if (String(state?.password || "").length < MIN_PASSWORD_LENGTH) return `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
   if (state?.password !== state?.password2) return "Passwords do not match.";
+  if (!String(state?.setup_token || "").trim()) return "Setup token is required.";
   return "";
 }
 
@@ -103,7 +106,7 @@ export function wireLiveAppAuthValidation(root, state, errorId = "", saveBtn = n
     errEl.classList.toggle("show", !!next);
   };
 
-  for (const sel of ['[data-field="username"]', '[data-field="password"]', '[data-field="password2"]']) {
+  for (const sel of ['[data-field="username"]', '[data-field="password"]', '[data-field="password2"]', '[data-field="setup_token"]']) {
     const el = root.querySelector(sel);
     if (!el || el.dataset.liveAuthWired === "1") continue;
     el.addEventListener("input", update);
@@ -164,6 +167,11 @@ export function renderAppAuthFields({
         <label for="${escapeHtml(idPrefix)}-pass2">Confirm password</label>
         <input id="${escapeHtml(idPrefix)}-pass2" data-field="password2" type="password" autocomplete="new-password" placeholder="Repeat password" value="${escapeHtml(state?.password2)}">
       </div>
+      <div class="field full">
+        <label for="${escapeHtml(idPrefix)}-setup-token">Setup token</label>
+        <input id="${escapeHtml(idPrefix)}-setup-token" data-field="setup_token" type="text" autocomplete="off" placeholder="Paste the one-time setup token" value="${escapeHtml(state?.setup_token)}">
+        <div class="subtxt">Printed in the server's boot logs and saved to a <code>.setup_token</code> file in your config directory.</div>
+      </div>
     </div>
     <div class="${errCls}"${errAttr}>${escapeHtml(state?.error)}</div>
   `;
@@ -175,17 +183,20 @@ export function renderAppAuthFields({
   `;
 }
 
-export async function saveRequiredAppAuth({ username, password, keepPending = false }) {
+export async function saveRequiredAppAuth({ username, password, setupToken, keepPending = false }) {
   const user = String(username || "").trim();
   const pass = String(password || "");
+  const token = String(setupToken || "").trim();
   if (!user) throw new Error("Username is required");
   if (!pass) throw new Error("Password is required");
   if (pass.length < MIN_PASSWORD_LENGTH) throw new Error(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+  if (!token) throw new Error("Setup token is required");
 
   const data = await _postJson("/api/app-auth/credentials", {
     enabled: true,
     username: user,
     password: pass,
+    setup_token: token,
   });
   _markAuthSetupPending(keepPending);
   try { window.dispatchEvent(new Event("auth-changed")); } catch {}

--- a/assets/js/modals/setup-wizard/index.js
+++ b/assets/js/modals/setup-wizard/index.js
@@ -166,11 +166,13 @@ export default {
         await saveRequiredAppAuth({
           username: state.username,
           password: state.password,
+          setupToken: state.setup_token,
         });
         state.saving = false;
         state.error = "";
         state.password = "";
         state.password2 = "";
+        state.setup_token = "";
         try { window.notify?.("Sign-in enabled."); } catch {}
         try {
           const boot = window.__cwAuthBootstrapState || {};

--- a/assets/js/modals/upgrade-warning/index.js
+++ b/assets/js/modals/upgrade-warning/index.js
@@ -204,12 +204,14 @@ export default {
         await saveRequiredAppAuth({
           username: state.username,
           password: state.password,
+          setupToken: state.setup_token,
         });
         state.authReady = true;
         state.saving = false;
         state.error = "";
         state.password = "";
         state.password2 = "";
+        state.setup_token = "";
         state.step = requiresCleanReset ? "cleanup" : "migrate";
         notify(requiresCleanReset
           ? "Sign-in saved. You can now run the clean reset."

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -73,7 +73,7 @@ from services.scheduling import SyncScheduler
 from services.statistics import Stats
 
 from cw_platform.orchestrator import Orchestrator, minimal
-from cw_platform.config_base import load_config, save_config, CONFIG as CONFIG_DIR, setup_token_file
+from cw_platform.config_base import load_config, save_config, CONFIG as CONFIG_DIR, setup_token_file, write_setup_token
 from cw_platform.tls import ensure_self_signed_cert, resolve_tls_paths
 from cw_platform.orchestrator import canonical_key
 
@@ -195,10 +195,11 @@ def _apply_auth_reset_env_once() -> None:
         a["sessions"] = []
         a["last_login_at"] = 0
         save_config(cfg)
-        try:
-            setup_token_file().unlink(missing_ok=True)
-        except Exception:
-            pass
+        # Write a fresh token unconditionally rather than unlinking the old one and
+        # relying on _ensure_setup_token() to regenerate it below -- if the unlink
+        # ever failed, the stale token would silently keep working, defeating the
+        # "old token can't be replayed after a reset" guarantee.
+        write_setup_token(secrets.token_urlsafe(24))
         print("[BOOT] CW_RESET_AUTH_ONCE detected: app authentication was reset. Remove the env var and set a new username/password in the UI.")
     except Exception as exc:
         print(f"[BOOT] CW_RESET_AUTH_ONCE failed: {exc}")
@@ -215,6 +216,10 @@ def _ensure_setup_token() -> None:
     token_path = setup_token_file()
     try:
         if token_path.exists():
+            try:
+                os.chmod(token_path, 0o600)
+            except Exception:
+                pass
             existing = token_path.read_text(encoding="utf-8").strip()
             if existing:
                 print(f"[BOOT] Setup required. One-time setup token: {existing}")
@@ -222,11 +227,7 @@ def _ensure_setup_token() -> None:
                 return
 
         token = secrets.token_urlsafe(24)
-        token_path.write_text(token + "\n", encoding="utf-8")
-        try:
-            os.chmod(token_path, 0o600)
-        except Exception:
-            pass
+        write_setup_token(token)
         print(f"[BOOT] Setup required. One-time setup token: {token}")
         print(f"[BOOT] Provide this token as \"setup_token\" in POST /api/app-auth/credentials, or read it from {token_path}.")
     except Exception as exc:

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -15,6 +15,7 @@ import sys
 sys.modules.setdefault("crosswatch", sys.modules[__name__])
 import os
 import re
+import secrets
 import socket
 import threading
 import time
@@ -72,7 +73,7 @@ from services.scheduling import SyncScheduler
 from services.statistics import Stats
 
 from cw_platform.orchestrator import Orchestrator, minimal
-from cw_platform.config_base import load_config, save_config, CONFIG as CONFIG_DIR
+from cw_platform.config_base import load_config, save_config, CONFIG as CONFIG_DIR, setup_token_file
 from cw_platform.tls import ensure_self_signed_cert, resolve_tls_paths
 from cw_platform.orchestrator import canonical_key
 
@@ -194,9 +195,42 @@ def _apply_auth_reset_env_once() -> None:
         a["sessions"] = []
         a["last_login_at"] = 0
         save_config(cfg)
+        try:
+            setup_token_file().unlink(missing_ok=True)
+        except Exception:
+            pass
         print("[BOOT] CW_RESET_AUTH_ONCE detected: app authentication was reset. Remove the env var and set a new username/password in the UI.")
     except Exception as exc:
         print(f"[BOOT] CW_RESET_AUTH_ONCE failed: {exc}")
+
+def _ensure_setup_token() -> None:
+    try:
+        cfg = load_config() or {}
+    except Exception as exc:
+        print(f"[BOOT] Could not load config to check setup token: {exc}")
+        return
+    if not app_auth_setup_lock_required(cfg):
+        return
+
+    token_path = setup_token_file()
+    try:
+        if token_path.exists():
+            existing = token_path.read_text(encoding="utf-8").strip()
+            if existing:
+                print(f"[BOOT] Setup required. One-time setup token: {existing}")
+                print(f"[BOOT] Provide this token as \"setup_token\" in POST /api/app-auth/credentials, or read it from {token_path}.")
+                return
+
+        token = secrets.token_urlsafe(24)
+        token_path.write_text(token + "\n", encoding="utf-8")
+        try:
+            os.chmod(token_path, 0o600)
+        except Exception:
+            pass
+        print(f"[BOOT] Setup required. One-time setup token: {token}")
+        print(f"[BOOT] Provide this token as \"setup_token\" in POST /api/app-auth/credentials, or read it from {token_path}.")
+    except Exception as exc:
+        print(f"[BOOT] Failed to prepare setup token: {exc}")
 
 def _is_static_noise(path: str, status: int) -> bool:
     if path.startswith("/assets/") or path.startswith("/favicon"):
@@ -354,6 +388,7 @@ def _compute_next_run_from_cfg(scfg: dict[str, Any] | None, now_ts: int | None =
 
 # API
 _apply_auth_reset_env_once()
+_ensure_setup_token()
 app = FastAPI()
 app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=5)
 

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -47,6 +47,24 @@ def _config_key_file() -> Path:
 def setup_token_file() -> Path:
     return CONFIG / ".setup_token"
 
+def write_setup_token(token: str) -> None:
+    """Persist the one-time setup token with 0600 permissions from the moment the
+    file is created (not chmod'd after the fact), so it's never briefly readable
+    at the umask's default mode. Also re-tightens an existing file's permissions,
+    in case it predates this."""
+    path = setup_token_file()
+    fd = os.open(str(path), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(token + "\n")
+    except Exception:
+        os.close(fd)
+        raise
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        pass
+
 def _normalize_fernet_key(raw: str | bytes) -> bytes:
     data = raw.encode("utf-8") if isinstance(raw, str) else bytes(raw)
     data = data.strip()

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -44,6 +44,9 @@ _ENC_PREFIX = "enc:v1:"
 def _config_key_file() -> Path:
     return CONFIG / ".cw_master_key"
 
+def setup_token_file() -> Path:
+    return CONFIG / ".setup_token"
+
 def _normalize_fernet_key(raw: str | bytes) -> bytes:
     data = raw.encode("utf-8") if isinstance(raw, str) else bytes(raw)
     data = data.strip()

--- a/tests/test_app_auth_api.py
+++ b/tests/test_app_auth_api.py
@@ -432,7 +432,7 @@ def test_credentials_accepts_and_consumes_valid_setup_token(monkeypatch, tmp_pat
     assert not token_path.exists()
 
 
-def test_clear_sessions_revokes_paired_mobile_devices(monkeypatch) -> None:
+def test_logout_all_revokes_paired_mobile_devices(monkeypatch) -> None:
     from api import appAuthAPI as auth
 
     cfg = _auth_cfg()
@@ -452,3 +452,82 @@ def test_clear_sessions_revokes_paired_mobile_devices(monkeypatch) -> None:
 
     assert resp.status_code == 200
     assert cfg["mobile_auth"]["devices"][0]["revoked_at"] > 0
+
+
+def test_credentials_password_change_revokes_mobile_devices(monkeypatch) -> None:
+    from api import appAuthAPI as auth
+
+    cfg = _auth_cfg()
+    cfg["mobile_auth"] = {
+        "enabled": True,
+        "devices": [{"id": "dev1", "token_hash": "abc", "revoked_at": 0, "expires_at": 9_999_999_999}],
+        "pairings": [],
+    }
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+
+    seed_req = _request("/api/app-auth/login")
+    session_token, _exp = auth._issue_session(cfg, seed_req)
+    req = _request("/api/app-auth/credentials", headers={"cookie": f"{auth.COOKIE_NAME}={session_token}"})
+
+    resp = auth.api_set_credentials(req, {"enabled": True, "username": "admin", "password": "newpassword1"})
+
+    assert resp.status_code == 200
+    assert cfg["mobile_auth"]["devices"][0]["revoked_at"] > 0
+
+
+def test_credentials_save_without_password_change_does_not_revoke_mobile_devices(monkeypatch) -> None:
+    # A benign settings tweak (e.g. remember-session preference) hits this same
+    # endpoint with enabled=True and no password. It must not revoke paired
+    # mobile devices -- only an actual password rotation should.
+    from api import appAuthAPI as auth
+
+    cfg = _auth_cfg()
+    cfg["mobile_auth"] = {
+        "enabled": True,
+        "devices": [{"id": "dev1", "token_hash": "abc", "revoked_at": 0, "expires_at": 9_999_999_999}],
+        "pairings": [],
+    }
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+
+    seed_req = _request("/api/app-auth/login")
+    session_token, _exp = auth._issue_session(cfg, seed_req)
+    req = _request("/api/app-auth/credentials", headers={"cookie": f"{auth.COOKIE_NAME}={session_token}"})
+
+    resp = auth.api_set_credentials(
+        req,
+        {
+            "enabled": True,
+            "username": "admin",
+            "password": "",
+            "remember_session_enabled": True,
+            "remember_session_days": 60,
+        },
+    )
+
+    assert resp.status_code == 200
+    assert cfg["mobile_auth"]["devices"][0]["revoked_at"] == 0
+
+
+def test_disabling_auth_mints_a_fresh_setup_token(monkeypatch) -> None:
+    # Once the token that gated the very first setup is consumed, disabling auth
+    # re-enters the setup-locked state. Without minting a new token here, no one
+    # could ever pass the setup-token gate again short of restarting the process.
+    from api import appAuthAPI as auth
+
+    cfg = _auth_cfg()
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+    written: dict[str, str] = {}
+    monkeypatch.setattr(auth, "write_setup_token", lambda token: written.setdefault("token", token))
+
+    seed_req = _request("/api/app-auth/login")
+    session_token, _exp = auth._issue_session(cfg, seed_req)
+    req = _request("/api/app-auth/credentials", headers={"cookie": f"{auth.COOKIE_NAME}={session_token}"})
+
+    resp = auth.api_set_credentials(req, {"enabled": False})
+
+    assert resp.status_code == 200
+    assert cfg["app_auth"]["enabled"] is False
+    assert written.get("token")

--- a/tests/test_app_auth_api.py
+++ b/tests/test_app_auth_api.py
@@ -153,6 +153,8 @@ def test_bootstrap_credentials_still_work_without_origin(monkeypatch) -> None:
     }
     monkeypatch.setattr(auth, "load_config", lambda: cfg)
     monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(auth, "verify_setup_token", lambda *_a, **_k: True)
+    monkeypatch.setattr(auth, "_consume_setup_token", lambda: None)
 
     req = _request("/api/app-auth/credentials")
     r = auth.api_set_credentials(req, {"enabled": True, "username": "admin", "password": "secrett1"})
@@ -202,6 +204,8 @@ def test_credentials_clamp_and_store_remember_session_settings(monkeypatch) -> N
     cfg = _auth_cfg(enabled=False)
     monkeypatch.setattr(auth, "load_config", lambda: cfg)
     monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(auth, "verify_setup_token", lambda *_a, **_k: True)
+    monkeypatch.setattr(auth, "_consume_setup_token", lambda: None)
 
     req = _request("/api/app-auth/credentials")
     resp = auth.api_set_credentials(
@@ -227,6 +231,8 @@ def test_credentials_clear_reset_required_flag(monkeypatch) -> None:
     cfg["app_auth"]["reset_required"] = True
     monkeypatch.setattr(auth, "load_config", lambda: cfg)
     monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(auth, "verify_setup_token", lambda *_a, **_k: True)
+    monkeypatch.setattr(auth, "_consume_setup_token", lambda: None)
 
     req = _request("/api/app-auth/credentials")
     resp = auth.api_set_credentials(
@@ -250,6 +256,8 @@ def test_credentials_mark_upgrade_pending_when_config_outdated(monkeypatch) -> N
     monkeypatch.setattr(auth, "_current_version_text", lambda: "0.9.14")
     monkeypatch.setattr(auth, "load_config", lambda: cfg)
     monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(auth, "verify_setup_token", lambda *_a, **_k: True)
+    monkeypatch.setattr(auth, "_consume_setup_token", lambda: None)
 
     req = _request("/api/app-auth/credentials")
     resp = auth.api_set_credentials(
@@ -307,6 +315,8 @@ def test_credentials_reject_too_short_password(monkeypatch) -> None:
     cfg = _auth_cfg(enabled=False)
     monkeypatch.setattr(auth, "load_config", lambda: cfg)
     monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(auth, "verify_setup_token", lambda *_a, **_k: True)
+    monkeypatch.setattr(auth, "_consume_setup_token", lambda: None)
 
     req = _request("/api/app-auth/credentials")
     resp = auth.api_set_credentials(
@@ -372,3 +382,73 @@ def test_login_timeout_steps_up_to_five_and_ten_minutes(monkeypatch) -> None:
     assert last is not None
     assert last.status_code == 429
     assert _json_body(last)["retry_after"] == 600
+
+
+def test_credentials_rejects_missing_or_wrong_setup_token(monkeypatch, tmp_path) -> None:
+    from api import appAuthAPI as auth
+
+    cfg = _auth_cfg(enabled=False)
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(auth, "setup_token_file", lambda: tmp_path / ".setup_token")
+    (tmp_path / ".setup_token").write_text("real-token\n", encoding="utf-8")
+
+    req = _request("/api/app-auth/credentials")
+
+    no_token = auth.api_set_credentials(req, {"enabled": True, "username": "admin", "password": "secrett1"})
+    assert no_token.status_code == 401
+
+    wrong_token = auth.api_set_credentials(
+        req,
+        {"enabled": True, "username": "admin", "password": "secrett1", "setup_token": "wrong-token"},
+    )
+    assert wrong_token.status_code == 401
+
+    # Config was never touched by either rejected attempt.
+    assert cfg["app_auth"]["username"] == "admin"
+    assert cfg["app_auth"]["enabled"] is False
+
+
+def test_credentials_accepts_and_consumes_valid_setup_token(monkeypatch, tmp_path) -> None:
+    from api import appAuthAPI as auth
+
+    cfg = _auth_cfg(enabled=False)
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+    token_path = tmp_path / ".setup_token"
+    monkeypatch.setattr(auth, "setup_token_file", lambda: token_path)
+    token_path.write_text("real-token\n", encoding="utf-8")
+
+    req = _request("/api/app-auth/credentials")
+    resp = auth.api_set_credentials(
+        req,
+        {"enabled": True, "username": "admin", "password": "secrett1", "setup_token": "real-token"},
+    )
+    assert resp.status_code == 200
+    assert cfg["app_auth"]["username"] == "admin"
+
+    # The token is one-time use: the file is gone, so a replay with the same
+    # value now fails even against a still-unconfigured instance.
+    assert not token_path.exists()
+
+
+def test_clear_sessions_revokes_paired_mobile_devices(monkeypatch) -> None:
+    from api import appAuthAPI as auth
+
+    cfg = _auth_cfg()
+    cfg["mobile_auth"] = {
+        "enabled": True,
+        "devices": [{"id": "dev1", "token_hash": "abc", "revoked_at": 0, "expires_at": 9_999_999_999}],
+        "pairings": [],
+    }
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+
+    seed_req = _request("/api/app-auth/login")
+    session_token, _exp = auth._issue_session(cfg, seed_req)
+
+    req = _request("/api/app-auth/logout-all", headers={"cookie": f"{auth.COOKIE_NAME}={session_token}"})
+    resp = auth.api_logout_all(req)
+
+    assert resp.status_code == 200
+    assert cfg["mobile_auth"]["devices"][0]["revoked_at"] > 0

--- a/tests/test_mobile_api.py
+++ b/tests/test_mobile_api.py
@@ -122,6 +122,31 @@ def test_mobile_pairing_qr_requires_qrcode(monkeypatch) -> None:
     assert missing.value.detail == "mobile_qr_dependency_missing"
 
 
+def test_revoke_all_devices_locks_out_a_paired_device(monkeypatch) -> None:
+    from api import mobileAPI as mobile
+
+    mobile._PAIRING_CLAIM_FAILS.clear()
+    cfg: dict = {"mobile_auth": {"enabled": True, "devices": [], "pairings": []}}
+    monkeypatch.setattr(mobile, "load_config", lambda: cfg)
+    monkeypatch.setattr(mobile, "save_config", lambda next_cfg: cfg.update(next_cfg))
+    monkeypatch.setattr(mobile, "_activity_payload", lambda: ([], 0))
+    monkeypatch.setattr(mobile, "_scheduler_label", lambda: ("Disabled", "Not scheduled"))
+    monkeypatch.setattr(mobile, "_watching_label", lambda: "Nothing playing")
+    monkeypatch.setattr(mobile, "_library_payload", lambda: [])
+
+    start_data = _json_body(mobile.mobile_pairing_start(_request("/api/mobile/pairing/start"), {"device_name": "Tablet"}))
+    token = _json_body(mobile.mobile_pairing_claim(_request("/api/mobile/pairing/claim"), {"code": start_data["code"], "device_name": "Tablet"}))["token"]
+
+    authed = _request("/api/mobile/summary", method="GET", headers={"authorization": f"Bearer {token}"})
+    assert _json_body(mobile.mobile_summary(authed))["server_name"] == "CrossWatch"
+
+    mobile.revoke_all_devices(cfg)
+
+    with pytest.raises(HTTPException) as missing:
+        mobile.mobile_summary(authed)
+    assert missing.value.status_code == 401
+
+
 def test_mobile_pairing_claim_rate_limits_bad_codes(monkeypatch) -> None:
     from api import mobileAPI as mobile
 


### PR DESCRIPTION
## Summary

Fixes two findings from a recent security audit of this repo (full audit report available on request):

- **Unauthenticated admin takeover via `POST /api/app-auth/credentials`**: this endpoint is reachable with zero authentication whenever `setup_lock_required(cfg)` is true — true on first boot, and true again any time `CW_RESET_AUTH_ONCE=1` recovers a forgotten password on an already-populated, live instance. Anyone who reached the instance first could claim it and walk away with a valid admin session. It now requires a one-time **setup token**: generated at boot, printed to the server logs, and written to `.setup_token` (chmod 0600) under `CONFIG_BASE`. The token is verified with a constant-time comparison, consumed on first successful use, and regenerated whenever `CW_RESET_AUTH_ONCE` fires. The setup wizard UI now collects and submits this token alongside username/password.
- **Mobile device tokens survive password rotation**: `_clear_sessions()` — called on password change, disabling auth, "sign out everywhere", and `apply-now` — only cleared `app_auth.sessions`, so a mobile companion-app device paired during a compromise kept its (up to 1-year) bearer token indefinitely, even after the admin rotated their password believing they'd evicted the intruder. `_clear_sessions()` now also revokes every paired mobile device.

## Notes for review

- `.setup_token` is deliberately **not** added to `services/backups.py`'s `_APP_STATE_FILES` allowlist — it's a short-lived, boot-scoped secret, not app state, and shouldn't ride along in exported backups.
- The only other caller of `POST /api/app-auth/credentials` (`assets/helpers/settings-save.js`, the already-authenticated "change password" flow in Settings) is unaffected — it never hits the setup-locked branch, so it needs no changes.
- Four pre-existing tests that exercised the pre-auth path in `tests/test_app_auth_api.py` were updated to bypass the new gate via `monkeypatch.setattr(auth, "verify_setup_token", lambda *_a, **_k: True)`, since they test unrelated behavior (remember-session clamping, reset-flag clearing, upgrade-pending marking, password-length validation).

## Test plan

- [x] `pytest tests/test_app_auth_api.py tests/test_mobile_api.py -q` — all pass, including new tests for: reject missing/wrong setup token, accept + consume a valid token, `_clear_sessions` revokes paired mobile devices, and a revoked device is locked out of `/api/mobile/summary`.
- [x] Full repo `pytest` run — no new failures (4 pre-existing, unrelated failures confirmed present on unmodified `main` too: `test_setup_lock_not_required_when_up_to_date_without_auth`, `test_recent_scrobble_widget_uses_nested_history_sync_item_art`, `test_episode_still_art_is_fetched_and_cached`, `test_same_title_with_matching_progress_can_still_combine_across_profiles`).
- [x] Manual boot check against a fresh `CONFIG_BASE`: confirmed `[BOOT] Setup required. One-time setup token: ...` prints, `.setup_token` is written with `0600` perms, a reboot before setup completes reprints the same token (no regeneration), and a live server correctly 401s with no/wrong token, 200s with the correct token, and 401s on replay with the now-consumed token.

https://claude.ai/code/session_01MsE6XJfwszxEE7wDKcvTeo