### PR TITLE
feat: automate versioning and releases via semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
-    # main = post-merge run. renovate/** lets Renovate's branch-automerge updates
-    # (which never open a PR) run `test` on the branch, so the default-branch
-    # ruleset (required `test (3.14)` check, pull_request rule dropped) can
-    # fast-forward main once the branch is green.
-    branches: [main, 'renovate/**']
+    # main/beta = post-merge run. renovate/** lets Renovate's branch-automerge
+    # updates (which never open a PR) run `test` on the branch, so the
+    # default-branch ruleset (required `test (3.14)` check, pull_request rule
+    # dropped) can fast-forward main once the branch is green.
+    branches: [main, beta, 'renovate/**']
   pull_request:
-    branches: [main]
+    branches: [main, beta]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,87 +2,23 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*"
-  workflow_dispatch:
+    branches:
+      - main
+      - beta
 
-env:
-  IMAGE: ghcr.io/${{ github.repository_owner }}/crosswatch
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
-permissions:
-  contents: read
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.14"]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt -r requirements-dev.txt
-
-      - name: Run tests
-        run: python -m pytest
-
-  docker:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
-        id: meta
-        with:
-          images: ${{ env.IMAGE }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest
-
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   release:
-    needs: [test, docker]
-    runs-on: ubuntu-latest
+    uses: jabrown93/.github/.github/workflows/docker-release.yml@71c3af9fc09ce87b086cc058773380acaf2b1299 # v1.2.0
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          fetch-depth: 0
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          generate_release_notes: true
+      packages: write
+      id-token: write
+    with:
+      image: ghcr.io/jabrown93/crosswatch
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,0 +1,47 @@
+// semantic-release configuration.
+//
+// Versioning is automated from Conventional Commits:
+//   * push to `main` -> stable release (feat -> minor, fix/perf -> patch, ! -> major)
+//   * push to `beta` -> prerelease (vX.Y.Z-beta.N)
+//
+// Dependency bumps intentionally do NOT cut a release on ordinary pushes. Renovate
+// labels them fix(deps) (runtime deps), chore(deps) (dev deps / lock maintenance),
+// or build(deps) — fix would otherwise trigger a patch via the default rules, so it
+// is explicitly suppressed here. A weekly scheduled workflow run (add one in
+// release.yml if desired, mirroring AURA's) can set RELEASE_DEPS=true to promote
+// accumulated dependency commits to a single patch release.
+//
+// This file is CommonJS (there is no root package.json with "type": "module");
+// semantic-release loads it via cosmiconfig.
+
+const releaseDeps = process.env.RELEASE_DEPS === "true";
+
+// Custom rules are evaluated before commit-analyzer's defaults, and the first
+// match wins — so `release: false` on fix(deps) suppresses the default fix->patch.
+// chore/build already don't release by default; they only need promotion when
+// RELEASE_DEPS is set.
+const depReleaseRules = releaseDeps
+  ? [
+      { type: "fix", scope: "deps", release: "patch" },
+      { type: "chore", scope: "deps", release: "patch" },
+      { type: "build", scope: "deps", release: "patch" },
+    ]
+  : [{ type: "fix", scope: "deps", release: false }];
+
+module.exports = {
+  branches: ["main", { name: "beta", prerelease: true }],
+  tagFormat: "v${version}",
+  plugins: [
+    ["@semantic-release/commit-analyzer", { releaseRules: depReleaseRules }],
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", { changelogFile: "CHANGELOG.md" }],
+    "@semantic-release/github",
+    [
+      "@semantic-release/git",
+      {
+        assets: ["CHANGELOG.md"],
+        message: "chore(release): v${nextRelease.version} [skip ci]",
+      },
+    ],
+  ],
+};

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,13 @@ FROM dhi.io/python:3.14.6-alpine3.24
 
 LABEL org.opencontainers.image.description="One brain for all your media syncs A single place to configure everything."
 
+# Baked in by CI (jabrown93/.github/docker-release.yml passes
+# --build-arg APP_VERSION=v<version>); api/versionAPI.py reads this via
+# os.getenv("APP_VERSION", ...) to report the real release instead of the
+# hardcoded fallback. Defaults to "dev" for a local `docker build` without it.
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app \


### PR DESCRIPTION
## Summary
- Replace the manual tag-push release flow with semantic-release: push to `main` cuts a stable release, push to `beta` cuts a prerelease (`vX.Y.Z-beta.N`).
- Adopt the new shared `jabrown93/.github/docker-release.yml` reusable workflow (pinned `v1.2.0`) instead of a bespoke image pipeline — version bump, `CHANGELOG.md`, tag, GitHub Release, and signed multi-arch GHCR image are one automated step.
- `ci.yml` now also runs the `test` check on `beta` so the branch-protection ruleset has something to gate on once `beta` exists.

## Follow-up (not in this PR, admin actions)
- Extend the existing rulesets (`branch-integrity`, `require-pull-request`, `require-status-checks`, `require-up-to-date`) to also cover `refs/heads/beta` — currently `~DEFAULT_BRANCH` only.
- Add repo secrets `APP_ID`/`APP_PRIVATE_KEY` (the release GitHub App used by the other automated repos) — none exist here yet.
- Create the `beta` branch.

## Test plan
- [x] `yq eval '.'` on both edited workflow files — valid YAML
- [x] `.releaserc.js` loads via `node -e "require('./.releaserc.js')"` and parses as expected
- [ ] After merge + admin follow-ups: confirm a `push: beta` run publishes a prerelease image and GitHub Release