### PR TITLE
ci(release): activate and correct the weekly dependency roll-up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - main
       - beta
+  # Weekly roll-up of the fix(deps) commits that .releaserc.js suppresses on
+  # push, promoted into a single patch release. GitHub only fires schedule
+  # from the default branch, so this sweeps main only; use the manual trigger
+  # below to sweep beta.
+  schedule:
+    - cron: '0 9 * * 1' # Mondays 09:00 UTC — weekly dependency roll-up
+  # Also sets RELEASE_DEPS, so a manual run is an on-demand dependency sweep
+  # (and the only way to promote beta's suppressed fix(deps) commits).
+  workflow_dispatch: {}
 
 concurrency:
   group: release-${{ github.ref }}
@@ -12,7 +21,7 @@ concurrency:
 
 jobs:
   release:
-    uses: jabrown93/.github/.github/workflows/docker-release.yml@71c3af9fc09ce87b086cc058773380acaf2b1299 # v1.2.0
+    uses: jabrown93/.github/.github/workflows/docker-release.yml@644b89511f2e5143fb600246050eaf3aa5f532eb # v1.5.0
     permissions:
       contents: write
       packages: write

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -4,29 +4,30 @@
 //   * push to `main` -> stable release (feat -> minor, fix/perf -> patch, ! -> major)
 //   * push to `beta` -> prerelease (vX.Y.Z-beta.N)
 //
-// Dependency bumps intentionally do NOT cut a release on ordinary pushes. Renovate
-// labels them fix(deps) (runtime deps), chore(deps) (dev deps / lock maintenance),
-// or build(deps) — fix would otherwise trigger a patch via the default rules, so it
-// is explicitly suppressed here. A weekly scheduled workflow run (add one in
-// release.yml if desired, mirroring AURA's) can set RELEASE_DEPS=true to promote
-// accumulated dependency commits to a single patch release.
+// Routine runtime dependency bumps (fix(deps), from Renovate via the shared
+// preset) intentionally do NOT cut a release on ordinary pushes -- fix would
+// otherwise trigger a patch via the default rules, so it is explicitly
+// suppressed here. The weekly scheduled run in .github/workflows/release.yml
+// sets RELEASE_DEPS=true, which promotes the accumulated bumps into one patch
+// release. Vulnerability fixes are typed fix(security) by the preset, not
+// fix(deps), so they are unaffected by the suppression and still release
+// immediately. See jabrown93/.github's README, "Weekly dependency releases".
 //
 // This file is CommonJS (there is no root package.json with "type": "module");
 // semantic-release loads it via cosmiconfig.
 
 const releaseDeps = process.env.RELEASE_DEPS === "true";
 
-// Custom rules are evaluated before commit-analyzer's defaults, and the first
-// match wins — so `release: false` on fix(deps) suppresses the default fix->patch.
-// chore/build already don't release by default; they only need promotion when
-// RELEASE_DEPS is set.
-const depReleaseRules = releaseDeps
-  ? [
-      { type: "fix", scope: "deps", release: "patch" },
-      { type: "chore", scope: "deps", release: "patch" },
-      { type: "build", scope: "deps", release: "patch" },
-    ]
-  : [{ type: "fix", scope: "deps", release: false }];
+const depReleaseRules = [
+  // Required: commit-analyzer evaluates every matching custom rule and keeps
+  // the highest release type, so without this a breaking fix(deps)! would
+  // match ONLY the suppression rule below and never release. Listed first so
+  // the analyzer short-circuits on major.
+  { type: "fix", scope: "deps", breaking: true, release: "major" },
+  releaseDeps
+    ? { type: "fix", scope: "deps", release: "patch" }
+    : { type: "fix", scope: "deps", release: false },
+];
 
 module.exports = {
   branches: ["main", { name: "beta", prerelease: true }],


### PR DESCRIPTION
Onboards this repo to the weekly dependency roll-up added in [jabrown93/.github#27](https://github.com/jabrown93/.github/pull/27). Unlike the other consumers, this repo already had **half** of the pattern — and the missing half is an active bug.

## The bug

`.releaserc.js` already suppressed `fix(deps)` on push, gated on `RELEASE_DEPS`. But **nothing ever set `RELEASE_DEPS`** — the config's own comment conceded it, saying a weekly run could be added to `release.yml` *"if desired"*. It never was.

So today, `fix(deps)` commits are suppressed on push and then **never promoted**. Dependency bumps only reach a release when an unrelated `feat`/`fix` happens to cut one. That's strictly worse than not having the pattern at all. This PR adds the scheduled run that actually performs the roll-up.

## Two rule bugs, both inherited from AURA's original

**1. The weekly run promoted `chore(deps)` and `build(deps)` to patch.** Under the shared Renovate preset those are dev/test/CI-only changes, so a week containing only dev-dependency bumps would cut a release with no runtime change in it. Only `fix(deps)` is promoted now.

**2. A breaking `fix(deps)!` never released at all.** It matched only the suppression rule. commit-analyzer evaluates *every* matching custom rule and keeps the highest release type, so an explicit `breaking → major` rule is required. Verified: without it, `fix(deps)!` with a `BREAKING CHANGE:` footer returns `null`.

Also drops the comment claiming custom rules are "evaluated first-match-wins". Per commit-analyzer's own `analyze-commit.js` docstring it *"[finds] all the rules matching and return[s] the highest release type"* — the rule order here is not load-bearing (confirmed by swapping them).

## Resulting behavior

| commit | on push | on weekly / manual |
|---|---|---|
| `fix(deps): bump requests` | no release | **patch** |
| `fix(deps)!: …BREAKING` | **major** | **major** |
| `fix(security): bump urllib3` | **patch** | patch |
| `chore(deps): bump pytest` | no release | no release |
| `feat:` / `fix:` | minor / patch | unchanged |

**Security fixes are not delayed** — the preset types them `fix(security)`, which bypasses the suppression.

## Verification

- Config resolves correctly in separate processes: `RELEASE_DEPS=true` → `patch`, `false`/unset → suppressed.
- `branches`, `tagFormat`, and all **5 plugins** unchanged — diffed against the version on `main`.
- Release matrix verified against the real `commit-analyzer@13`.
- `actionlint` clean.

## Note

`schedule` only fires from the default branch, so this sweeps `main` only. `workflow_dispatch` also sets `RELEASE_DEPS`, so a manual run is the way to sweep `beta`.

Bumps `docker-release.yml` v1.2.0 → v1.5.0. Note the first weekly run after merge will roll up **every** `fix(deps)` commit accumulated since the suppression was introduced, so expect one patch release with a long dependency changelog.