### PR TITLE
ci: repoint release to jabrown93/ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   release:
-    uses: jabrown93/.github/.github/workflows/docker-release.yml@644b89511f2e5143fb600246050eaf3aa5f532eb # v1.5.0
+    uses: jabrown93/ci/.github/workflows/docker-release.yml@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # workflows-v1.0.0
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Repoint release to `jabrown93/ci`

`docker-release` moved to `jabrown93/ci` as a **reusable workflow**. The file at `workflows-v1.0.0` (@63fdb13) is **byte-identical** to `jabrown93/.github` v1.5.0 (verified by diff), so this is a **location-only** change — same `image`/`dockerfile`/`context`/`platforms` inputs, same `APP_ID`/`APP_PRIVATE_KEY` secrets, same two-job release→build-push-sign behavior.

```
uses: jabrown93/ci/.github/workflows/docker-release.yml@63fdb13 # workflows-v1.0.0
with:
  image: ghcr.io/jabrown93/crosswatch
```

The `release` job runs on push to `main`/`beta` (post-merge), so it is not exercised by this PR's checks; the byte-identical diff is the assurance. `ci:` commit → no release bump.
