### PR TITLE
refactor: consolidate duplicated logic across API, orchestrator, sinks, and JS modals

### DIFF
--- a/api/configAPI.py
+++ b/api/configAPI.py
@@ -323,6 +323,49 @@ def api_config() -> JSONResponse:
     cfg = base.redact_config(cfg)  # type: ignore[attr-defined]
     return _nostore(JSONResponse(cfg))
 
+def _finalize_config(env: dict[str, Any], cfg: dict[str, Any], *, ensure: bool = False) -> None:
+    """Normalize scrobble mode/features.watch, prune+norm pairs, and clear setup-wizard markers.
+
+    Shared by api_config_save and api_config_migrate; `ensure=True` additionally
+    runs env["ensure"](cfg) after pruning (migrate-only step).
+    """
+    sc = cfg.setdefault("scrobble", {})
+    sc_enabled = bool(sc.get("enabled", False))
+    mode = str(sc.get("mode") or "").strip().lower()
+    if mode not in {"webhook","watch"}:
+        legacy_webhook = bool((cfg.get("webhook") or {}).get("enabled"))
+        mode = "webhook" if legacy_webhook else ("watch" if sc_enabled else "")
+        if mode: sc["mode"] = mode
+    if mode == "webhook":
+        sc.setdefault("watch", {}).setdefault("autostart", bool(sc.get("watch", {}).get("autostart", False)))
+    elif mode != "watch":
+        sc["enabled"] = False
+
+    features = cfg.setdefault("features", {})
+    watch_feat = features.setdefault("watch", {})
+    watch_feat["enabled"] = bool(source_enabled(cfg, "watcher") and sc.get("watch", {}).get("autostart", False))
+
+    try:
+        env["prune"](cfg)
+        if ensure:
+            env["ensure"](cfg)
+        for p in (cfg.get("pairs") or []):
+            try: env["norm_pair"](p)
+            except Exception: pass
+    except Exception:
+        pass
+
+    # Setup-wizard marker: saved config then clear any auto-generated flag.
+    try:
+        ui = cfg.get("ui")
+        if isinstance(ui, dict):
+            ui.pop("_autogen", None)
+            ui.pop("_pending_upgrade_from_version", None)
+            _set_cfg_version_current(env, cfg)
+    except Exception:
+        pass
+
+
 @router.post("/config")
 def api_config_save(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
     env = _env()
@@ -460,39 +503,7 @@ def api_config_save(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
     except Exception:
         pass
 
-    sc = cfg.setdefault("scrobble", {})
-    sc_enabled = bool(sc.get("enabled", False))
-    mode = str(sc.get("mode") or "").strip().lower()
-    if mode not in {"webhook","watch"}:
-        legacy_webhook = bool((cfg.get("webhook") or {}).get("enabled"))
-        mode = "webhook" if legacy_webhook else ("watch" if sc_enabled else "")
-        if mode: sc["mode"] = mode
-    if mode == "webhook":
-        sc.setdefault("watch", {}).setdefault("autostart", bool(sc.get("watch", {}).get("autostart", False)))
-    elif mode != "watch":
-        sc["enabled"] = False
-
-    features = cfg.setdefault("features", {})
-    watch_feat = features.setdefault("watch", {})
-    watch_feat["enabled"] = bool(source_enabled(cfg, "watcher") and sc.get("watch", {}).get("autostart", False))
-
-    try:
-        env["prune"](cfg)
-        for p in (cfg.get("pairs") or []):
-            try: env["norm_pair"](p)
-            except Exception: pass
-    except Exception:
-        pass
-
-    # Setup-wizard marker: saved config then clear any auto-generated flag.
-    try:
-        ui = cfg.get("ui")
-        if isinstance(ui, dict):
-            ui.pop("_autogen", None)
-            ui.pop("_pending_upgrade_from_version", None)
-            _set_cfg_version_current(env, cfg)
-    except Exception:
-        pass
+    _finalize_config(env, cfg)
 
     env["save"](cfg)
 
@@ -552,42 +563,7 @@ def api_config_migrate() -> dict[str, Any]:
     except Exception:
         return {"ok": False, "error": "migration_overrides_failed"}
 
-    sc = cfg.setdefault("scrobble", {})
-    sc_enabled = bool(sc.get("enabled", False))
-    mode = str(sc.get("mode") or "").strip().lower()
-    if mode not in {"webhook","watch"}:
-        legacy_webhook = bool((cfg.get("webhook") or {}).get("enabled"))
-        mode = "webhook" if legacy_webhook else ("watch" if sc_enabled else "")
-        if mode:
-            sc["mode"] = mode
-    if mode == "webhook":
-        sc.setdefault("watch", {}).setdefault("autostart", bool(sc.get("watch", {}).get("autostart", False)))
-    elif mode != "watch":
-        sc["enabled"] = False
-
-    features = cfg.setdefault("features", {})
-    watch_feat = features.setdefault("watch", {})
-    watch_feat["enabled"] = bool(source_enabled(cfg, "watcher") and sc.get("watch", {}).get("autostart", False))
-
-    try:
-        env["prune"](cfg)
-        env["ensure"](cfg)
-        for p in (cfg.get("pairs") or []):
-            try:
-                env["norm_pair"](p)
-            except Exception:
-                pass
-    except Exception:
-        pass
-
-    try:
-        ui = cfg.get("ui")
-        if isinstance(ui, dict):
-            ui.pop("_autogen", None)
-            ui.pop("_pending_upgrade_from_version", None)
-            _set_cfg_version_current(env, cfg)
-    except Exception:
-        pass
+    _finalize_config(env, cfg, ensure=True)
 
     try:
         env["save"](cfg)

--- a/api/editorAPI.py
+++ b/api/editorAPI.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 import io
 import json
@@ -114,12 +114,33 @@ def _merge_blocks(a: list[str], b: list[str]) -> list[str]:
 
 
 
-def _load_policy_manual(kind: Kind, provider: str, provider_instance: str | None = None) -> tuple[dict[str, Any], list[str]]:
-    raw = _load_policy()
-    providers = raw.get("providers") or {}
-    if not isinstance(providers, dict):
-        return {}, []
+def _dedupe_block_list(blocks_raw: Any) -> list[str]:
+    """Case-insensitive de-dupe of a manual-block list, accepting either a list/tuple/set
+    of ids or a dict whose keys are ids (both shapes occur in stored policy/state json)."""
+    if isinstance(blocks_raw, (list, tuple, set)):
+        keys: Any = blocks_raw
+    elif isinstance(blocks_raw, dict):
+        keys = blocks_raw.keys()
+    else:
+        return []
 
+    blocks: list[str] = []
+    seen: set[str] = set()
+    for x in keys:
+        s = str(x).strip()
+        if not s:
+            continue
+        sl = s.lower()
+        if sl in seen:
+            continue
+        seen.add(sl)
+        blocks.append(s)
+    return blocks
+
+
+def _find_manual_node(providers: dict[str, Any], provider: str, provider_instance: str | None) -> dict[str, Any] | None:
+    """Look up a provider's node (case-insensitive), then descend into its instance
+    sub-node if `provider_instance` is not the default. Returns None if any step misses."""
     node = providers.get(provider)
     if not isinstance(node, dict):
         pl = str(provider).lower()
@@ -128,68 +149,21 @@ def _load_policy_manual(kind: Kind, provider: str, provider_instance: str | None
                 node = v
                 break
     if not isinstance(node, dict):
-        return {}, []
+        return None
 
     inst = normalize_instance_id(provider_instance)
     if inst != "default":
         insts = node.get("instances") or {}
         if not isinstance(insts, dict):
-            return {}, []
+            return None
         node = insts.get(inst)
         if not isinstance(node, dict):
-            return {}, []
-
-    f = node.get(kind) or {}
-    if not isinstance(f, dict):
-        return {}, []
-
-    blocks_raw = f.get("blocks") or []
-    blocks: list[str] = []
-    seen: set[str] = set()
-    if isinstance(blocks_raw, (list, tuple, set)):
-        for x in blocks_raw:
-            s = str(x).strip()
-            if not s:
-                continue
-            sl = s.lower()
-            if sl in seen:
-                continue
-            seen.add(sl)
-            blocks.append(s)
-    elif isinstance(blocks_raw, dict):
-        for k in blocks_raw.keys():
-            s = str(k).strip()
-            if not s:
-                continue
-            sl = s.lower()
-            if sl in seen:
-                continue
-            seen.add(sl)
-            blocks.append(s)
-
-    adds_raw = f.get("adds") or {}
-    adds_items: dict[str, Any] = {}
-    if isinstance(adds_raw, dict):
-        items = adds_raw.get("items") or {}
-        if isinstance(items, dict):
-            adds_items = {str(k): v for k, v in items.items()}
-    return adds_items, blocks
+            return None
+    return node
 
 
-def _save_policy_manual(
-    kind: Kind,
-    provider: str,
-    adds_items: dict[str, Any],
-    blocks: list[str],
-    provider_instance: str | None = None,
-) -> None:
-    adds_items = _canonicalize_manual_items(adds_items)
-    raw = _load_policy()
-    providers = raw.get("providers")
-    if not isinstance(providers, dict):
-        providers = {}
-        raw["providers"] = providers
-
+def _find_or_create_manual_node(providers: dict[str, Any], provider: str, provider_instance: str | None) -> dict[str, Any]:
+    """Same lookup as `_find_manual_node`, but creates the provider/instance node(s) when missing."""
     key = None
     if provider in providers:
         key = provider
@@ -219,11 +193,87 @@ def _save_policy_manual(
             in_node = {}
             insts[inst] = in_node
         node = in_node
+    return node
 
-    f = node.get(kind)
+
+def _load_manual_entry(
+    loader: Callable[[], dict[str, Any]],
+    kind: Kind,
+    provider: str,
+    provider_instance: str | None,
+    *,
+    wrap_in_manual: bool,
+) -> tuple[dict[str, Any], list[str]]:
+    """Shared core for `_load_policy_manual`/`_load_state_manual`: read `kind`'s adds/blocks
+    for a provider(+instance) out of the doc returned by `loader`. `wrap_in_manual` selects
+    whether `kind` lives directly under the provider node (policy doc) or under a "manual"
+    sub-key (state doc)."""
+    raw = loader()
+    providers = raw.get("providers") or {}
+    if not isinstance(providers, dict):
+        return {}, []
+
+    node = _find_manual_node(providers, provider, provider_instance)
+    if node is None:
+        return {}, []
+
+    if wrap_in_manual:
+        manual = node.get("manual") or {}
+        if not isinstance(manual, dict):
+            return {}, []
+        f = manual.get(kind) or {}
+    else:
+        f = node.get(kind) or {}
+    if not isinstance(f, dict):
+        return {}, []
+
+    blocks = _dedupe_block_list(f.get("blocks") or [])
+
+    adds_raw = f.get("adds") or {}
+    adds_items: dict[str, Any] = {}
+    if isinstance(adds_raw, dict):
+        items = adds_raw.get("items") or {}
+        if isinstance(items, dict):
+            adds_items = {str(k): v for k, v in items.items()}
+    return adds_items, blocks
+
+
+def _save_manual_entry(
+    loader: Callable[[], dict[str, Any]],
+    write_path: Path,
+    kind: Kind,
+    provider: str,
+    adds_items: dict[str, Any],
+    blocks: list[str],
+    provider_instance: str | None,
+    *,
+    wrap_in_manual: bool,
+) -> None:
+    """Shared core for `_save_policy_manual`/`_save_state_manual`: write `kind`'s adds/blocks
+    for a provider(+instance) into the doc returned by `loader`, then atomically write it
+    back to `write_path`. `wrap_in_manual` mirrors `_load_manual_entry`."""
+    adds_items = _canonicalize_manual_items(adds_items)
+    raw = loader()
+    providers = raw.get("providers")
+    if not isinstance(providers, dict):
+        providers = {}
+        raw["providers"] = providers
+
+    node = _find_or_create_manual_node(providers, provider, provider_instance)
+
+    if wrap_in_manual:
+        manual = node.get("manual")
+        if not isinstance(manual, dict):
+            manual = {}
+            node["manual"] = manual
+        container = manual
+    else:
+        container = node
+
+    f = container.get(kind)
     if not isinstance(f, dict):
         f = {}
-        node[kind] = f
+        container[kind] = f
 
     f["blocks"] = list(blocks or [])
 
@@ -233,7 +283,21 @@ def _save_policy_manual(
         f["adds"] = adds
     adds["items"] = dict(adds_items or {})
 
-    _atomic_write_json(_POLICY_PATH, raw)
+    _atomic_write_json(write_path, raw)
+
+
+def _load_policy_manual(kind: Kind, provider: str, provider_instance: str | None = None) -> tuple[dict[str, Any], list[str]]:
+    return _load_manual_entry(_load_policy, kind, provider, provider_instance, wrap_in_manual=False)
+
+
+def _save_policy_manual(
+    kind: Kind,
+    provider: str,
+    adds_items: dict[str, Any],
+    blocks: list[str],
+    provider_instance: str | None = None,
+) -> None:
+    _save_manual_entry(_load_policy, _POLICY_PATH, kind, provider, adds_items, blocks, provider_instance, wrap_in_manual=False)
 
 
 def _policy_from_state() -> dict[str, Any]:
@@ -633,68 +697,7 @@ def _save_state_items(kind: Kind, provider: str, items: dict[str, Any], provider
 
 
 def _load_state_manual(kind: Kind, provider: str, provider_instance: str | None = None) -> tuple[dict[str, Any], list[str]]:
-    raw = _load_current_state()
-    providers = raw.get("providers") or {}
-    if not isinstance(providers, dict):
-        return {}, []
-    node = providers.get(provider)
-    if not isinstance(node, dict):
-        pl = str(provider).lower()
-        for k, v in providers.items():
-            if str(k).lower() == pl and isinstance(v, dict):
-                node = v
-                break
-    if not isinstance(node, dict):
-        return {}, []
-
-    inst = normalize_instance_id(provider_instance)
-    if inst != "default":
-        insts = node.get("instances") or {}
-        if not isinstance(insts, dict):
-            return {}, []
-        node = insts.get(inst)
-        if not isinstance(node, dict):
-            return {}, []
-
-    manual = node.get("manual") or {}
-    if not isinstance(manual, dict):
-        return {}, []
-    f = manual.get(kind) or {}
-    if not isinstance(f, dict):
-        return {}, []
-
-    blocks_raw = f.get("blocks") or []
-    blocks: list[str] = []
-    seen: set[str] = set()
-    if isinstance(blocks_raw, (list, tuple, set)):
-        for x in blocks_raw:
-            s = str(x).strip()
-            if not s:
-                continue
-            sl = s.lower()
-            if sl in seen:
-                continue
-            seen.add(sl)
-            blocks.append(s)
-    elif isinstance(blocks_raw, dict):
-        for k in blocks_raw.keys():
-            s = str(k).strip()
-            if not s:
-                continue
-            sl = s.lower()
-            if sl in seen:
-                continue
-            seen.add(sl)
-            blocks.append(s)
-
-    adds_raw = f.get("adds") or {}
-    adds_items: dict[str, Any] = {}
-    if isinstance(adds_raw, dict):
-        items = adds_raw.get("items") or {}
-        if isinstance(items, dict):
-            adds_items = {str(k): v for k, v in items.items()}
-
-    return adds_items, blocks
+    return _load_manual_entry(_load_current_state, kind, provider, provider_instance, wrap_in_manual=True)
 
 
 def _save_state_manual(
@@ -704,62 +707,7 @@ def _save_state_manual(
     blocks: list[str],
     provider_instance: str | None = None,
 ) -> None:
-    adds_items = _canonicalize_manual_items(adds_items)
-    raw = _load_current_state()
-    providers = raw.get("providers")
-    if not isinstance(providers, dict):
-        providers = {}
-        raw["providers"] = providers
-
-    key = None
-    if provider in providers:
-        key = provider
-    else:
-        pl = str(provider).lower()
-        for k in providers.keys():
-            if str(k).lower() == pl:
-                key = str(k)
-                break
-    if key is None:
-        key = provider
-        providers[key] = {}
-
-    node = providers.get(key)
-    if not isinstance(node, dict):
-        node = {}
-        providers[key] = node
-
-    inst = normalize_instance_id(provider_instance)
-    if inst != "default":
-        insts = node.get("instances")
-        if not isinstance(insts, dict):
-            insts = {}
-            node["instances"] = insts
-        in_node = insts.get(inst)
-        if not isinstance(in_node, dict):
-            in_node = {}
-            insts[inst] = in_node
-        node = in_node
-
-    manual = node.get("manual")
-    if not isinstance(manual, dict):
-        manual = {}
-        node["manual"] = manual
-
-    f = manual.get(kind)
-    if not isinstance(f, dict):
-        f = {}
-        manual[kind] = f
-
-    f["blocks"] = list(blocks or [])
-
-    adds = f.get("adds")
-    if not isinstance(adds, dict):
-        adds = {}
-        f["adds"] = adds
-    adds["items"] = dict(adds_items or {})
-
-    _atomic_write_json(_STATE_PATH, raw)
+    _save_manual_entry(_load_current_state, _STATE_PATH, kind, provider, adds_items, blocks, provider_instance, wrap_in_manual=True)
 
 def _normalize_kind(val: str | None) -> Kind:
     k = (val or "watchlist").strip().lower()
@@ -1002,29 +950,7 @@ def api_editor_save_state(payload: dict[str, Any] = Body(...)) -> dict[str, Any]
 
         inst = normalize_instance_id(payload.get("provider_instance"))
 
-        blocks_raw = payload.get("blocks") or []
-        blocks: list[str] = []
-        seen: set[str] = set()
-        if isinstance(blocks_raw, (list, tuple, set)):
-            for x in blocks_raw:
-                s = str(x).strip()
-                if not s:
-                    continue
-                sl = s.lower()
-                if sl in seen:
-                    continue
-                seen.add(sl)
-                blocks.append(s)
-        elif isinstance(blocks_raw, dict):
-            for k in blocks_raw.keys():
-                s = str(k).strip()
-                if not s:
-                    continue
-                sl = s.lower()
-                if sl in seen:
-                    continue
-                seen.add(sl)
-                blocks.append(s)
+        blocks = _dedupe_block_list(payload.get("blocks") or [])
 
         _save_policy_manual(kind, provider, items, blocks, inst)
         if _STATE_PATH.exists():

--- a/api/metaAPI.py
+++ b/api/metaAPI.py
@@ -609,6 +609,50 @@ def _art_candidates(
     return []
 
 
+def _cached_art_lookup(cache_root: Path, base: Path) -> tuple[str, str] | None:
+    """Return (path, mime) if `base`'s cache entry (sidecar meta json plus its matching
+    art file) is already fully cached, else None. Shared by get_art_file / get_episode_still_file."""
+    meta_path = base.with_suffix(".json")
+    if not (meta_path.exists() and _read_json(meta_path).get("url")):
+        return None
+    for f in _cache_matches(cache_root, base.name):
+        if f.suffix.lower() != ".json" and f.exists():
+            ext = f.suffix.lower()
+            mime = "image/jpeg" if ext in {".jpg", ".jpeg"} else "image/png" if ext == ".png" else "application/octet-stream"
+            return str(f), mime
+    return None
+
+
+def _store_art(
+    cache_root: Path,
+    base: Path,
+    meta_path: Path,
+    dest: Path,
+    src_url: str,
+    *,
+    debug_fields: dict[str, Any],
+) -> tuple[str, str]:
+    """Purge any stale cached file(s) for `base` whose recorded url no longer matches
+    `src_url`, log an art_cache_hit/miss debug event, then download (or reuse) `dest` and
+    refresh its sidecar meta json. Shared tail of get_art_file / get_episode_still_file —
+    callers must have already validated `meta_path`/`dest` via _ensure_under_root."""
+    prev_url = _read_json(meta_path).get("url") if meta_path.exists() else None
+    if (prev_url and prev_url != src_url) or (not meta_path.exists()):
+        for f in _cache_matches(cache_root, base.name):
+            if f.name != meta_path.name:
+                try:
+                    f.unlink()
+                except Exception:
+                    pass
+
+    art_hit = bool(dest.exists() and prev_url == src_url)
+    _meta_debug("art_cache_hit" if art_hit else "art_cache_miss", **debug_fields)
+
+    path, mime = _cache_download(src_url, dest)
+    _write_json(meta_path, {"url": src_url, "ts": int(time.time())})
+    return str(path), mime
+
+
 def get_art_file(
     api_key: str,
     typ: str,
@@ -636,15 +680,8 @@ def get_art_file(
     base = cache_root / f"{safe_typ}_{safe_tmdb_id}_{safe_kind}_{loc_tag}_{safe_size}"
     meta_path = base.with_suffix(".json")
 
-    cached_art = None
-    if meta_path.exists() and _read_json(meta_path).get("url"):
-        for f in cache_root.glob(base.name + ".*"):
-            if f.suffix.lower() != ".json" and f.exists():
-                cached_art = f
-                break
-    if cached_art:
-        ext = cached_art.suffix.lower()
-        mime = "image/jpeg" if ext in {".jpg", ".jpeg"} else "image/png" if ext == ".png" else "application/octet-stream"
+    cached = _cached_art_lookup(cache_root, base)
+    if cached:
         _meta_debug(
             "art_cache_hit",
             type=typ,
@@ -653,7 +690,7 @@ def get_art_file(
             size=safe_size,
             locale=eff_locale or "any",
         )
-        return str(cached_art), mime
+        return cached
 
     meta = get_meta(api_key, typ, str(tmdb_id), cache_dir=cache_dir, need={art_kind: True}, locale=eff_locale) or {}
     eff_locale = eff_locale or meta.get("locale") or None
@@ -675,9 +712,6 @@ def get_art_file(
     if not src_url:
         return str(_placeholder_poster()), "image/svg+xml"
 
-    base = cache_root / f"{safe_typ}_{safe_tmdb_id}_{safe_kind}_{loc_tag}_{safe_size}"
-    meta_path = base.with_suffix(".json")
-
     ext = Path(src_url.split("?", 1)[0]).suffix.lower() or ".jpg"
     if ext not in {".jpg", ".jpeg", ".png", ".webp"}:
         ext = ".jpg"
@@ -687,28 +721,10 @@ def get_art_file(
     _ensure_under_root(cache_root, meta_path)
     _ensure_under_root(cache_root, dest)
 
-    prev_url = _read_json(meta_path).get("url") if meta_path.exists() else None
-    if (prev_url and prev_url != src_url) or (not meta_path.exists()):
-        for f in cache_root.glob(base.name + ".*"):
-            if f.name != meta_path.name:
-                try:
-                    f.unlink()
-                except Exception:
-                    pass
-
-    art_hit = bool(dest.exists() and prev_url == src_url)
-    _meta_debug(
-        "art_cache_hit" if art_hit else "art_cache_miss",
-        type=typ,
-        tmdb_id=tmdb_id,
-        kind=art_kind,
-        size=size_tag,
-        locale=eff_locale or "any",
+    return _store_art(
+        cache_root, base, meta_path, dest, src_url,
+        debug_fields=dict(type=typ, tmdb_id=tmdb_id, kind=art_kind, size=size_tag, locale=eff_locale or "any"),
     )
-
-    path, mime = _cache_download(src_url, dest)
-    _write_json(meta_path, {"url": src_url, "ts": int(time.time())})
-    return str(path), mime
 
 
 def get_episode_still_file(
@@ -727,15 +743,8 @@ def get_episode_still_file(
     base = _cache_base_path(cache_root, cache_stem)
     meta_path = base.with_suffix(".json")
 
-    cached_art = None
-    if meta_path.exists() and _read_json(meta_path).get("url"):
-        for f in _cache_matches(cache_root, cache_stem):
-            if f.suffix.lower() != ".json" and f.exists():
-                cached_art = f
-                break
-    if cached_art:
-        ext = cached_art.suffix.lower()
-        mime = "image/jpeg" if ext in {".jpg", ".jpeg"} else "image/png" if ext == ".png" else "application/octet-stream"
+    cached = _cached_art_lookup(cache_root, base)
+    if cached:
         _meta_debug(
             "art_cache_hit",
             type="tv",
@@ -745,7 +754,7 @@ def get_episode_still_file(
             episode=episode,
             size=safe_size,
         )
-        return str(cached_art), mime
+        return cached
 
     def show_art_fallback() -> tuple[str, str]:
         last: tuple[str, str] | None = None
@@ -780,40 +789,11 @@ def get_episode_still_file(
     meta_path = _ensure_under_root(cache_root, meta_path)
     dest = _ensure_under_root(cache_root, dest)
 
-    prev_url = _read_json(meta_path).get("url") if meta_path.exists() else None
-    if (prev_url and prev_url != src_url) or (not meta_path.exists()):
-        for f in _cache_matches(cache_root, cache_stem):
-            if f.name != meta_path.name:
-                try:
-                    f.unlink()
-                except Exception:
-                    pass
-
-    art_hit = bool(dest.exists() and prev_url == src_url)
-    _meta_debug(
-        "art_cache_hit" if art_hit else "art_cache_miss",
-        type="tv",
-        tmdb_id=show_tmdb_id,
-        kind="still",
-        season=season,
-        episode=episode,
-        size=safe_size,
+    return _store_art(
+        cache_root, base, meta_path, dest, src_url,
+        debug_fields=dict(type="tv", tmdb_id=show_tmdb_id, kind="still", season=season, episode=episode, size=safe_size),
     )
 
-    path, mime = _cache_download(src_url, dest)
-    _write_json(meta_path, {"url": src_url, "ts": int(time.time())})
-    return str(path), mime
-
-
-def get_poster_file(
-    api_key: str,
-    typ: str,
-    tmdb_id: str | int,
-    size: str,
-    cache_dir: Path | str,
-    locale: str | None = None,
-) -> tuple[str, str]:
-    return get_art_file(api_key, typ, tmdb_id, size, cache_dir, locale=locale, kind="poster")
 
 def _tmdb_external_ids(entity: str, tmdb_id: str | int) -> dict[str, str]:
     try:

--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -960,6 +960,42 @@ def _load_state() -> dict[str, Any]:
         _STATE_CACHE["data"] = data
         _STATE_CACHE["checked_ts"] = now
     return data
+def _iter_feature_nodes(pdata: dict[str, Any], feat: str) -> list[dict[str, Any]]:
+    """Collect a provider's `feat` node from its state entry, plus the same feature
+    node under each of its `instances` sub-entries. Shared by _show_title_maps_from_state
+    and _episode_code_map_from_state."""
+    out: list[dict[str, Any]] = []
+    node = pdata.get(feat)
+    if isinstance(node, dict):
+        out.append(node)
+    insts = pdata.get("instances")
+    if isinstance(insts, dict):
+        for _iid, idata in insts.items():
+            if not isinstance(idata, dict):
+                continue
+            node2 = idata.get(feat)
+            if isinstance(node2, dict):
+                out.append(node2)
+    return out
+
+
+def _iter_baseline_items(node: dict[str, Any]) -> Iterator[tuple[Any, dict[str, Any]]]:
+    """Yield (key, item) pairs from a feature node's baseline.items, accepting either the
+    dict-of-items or list-of-items shape. Shared by _show_title_maps_from_state and
+    _episode_code_map_from_state."""
+    baseline = node.get("baseline")
+    base: dict[str, Any] = baseline if isinstance(baseline, dict) else node
+    items = base.get("items")
+    if isinstance(items, dict):
+        for k, it in items.items():
+            if isinstance(it, dict):
+                yield k, it
+    elif isinstance(items, list):
+        for it in items:
+            if isinstance(it, dict):
+                yield it.get("key"), it
+
+
 def _show_title_maps_from_state(state: dict[str, Any]) -> tuple[dict[str, str], dict[str, str]]:
     key_map: dict[str, str] = {}
     id_map: dict[str, str] = {}
@@ -979,42 +1015,13 @@ def _show_title_maps_from_state(state: dict[str, Any]) -> tuple[dict[str, str], 
         if k0 not in d:
             d[k0] = v0
 
-    def _iter_nodes(pdata: dict[str, Any], feat: str) -> list[dict[str, Any]]:
-        out: list[dict[str, Any]] = []
-        node = pdata.get(feat)
-        if isinstance(node, dict):
-            out.append(node)
-        insts = pdata.get("instances")
-        if isinstance(insts, dict):
-            for _iid, idata in insts.items():
-                if not isinstance(idata, dict):
-                    continue
-                node2 = idata.get(feat)
-                if isinstance(node2, dict):
-                    out.append(node2)
-        return out
-
     for _, pdata in provs.items():
         if not isinstance(pdata, dict):
             continue
 
         for feat in ("history", "ratings", "watchlist", "playlists"):
-            for node in _iter_nodes(pdata, feat):
-                baseline = node.get("baseline")
-                base: dict[str, Any] = baseline if isinstance(baseline, dict) else node
-                items = base.get("items")
-
-                if isinstance(items, dict):
-                    iters = items.items()
-                elif isinstance(items, list):
-                    iters = ((it.get("key"), it) for it in items if isinstance(it, dict))
-                else:
-                    continue
-
-                for k, it in iters:
-                    if not isinstance(it, dict):
-                        continue
-
+            for node in _iter_feature_nodes(pdata, feat):
+                for k, it in _iter_baseline_items(node):
                     typ = str(it.get("type") or "").lower()
                     is_show = typ in ("show", "series", "anime")
 
@@ -1083,38 +1090,12 @@ def _episode_code_map_from_state(state: dict[str, Any]) -> dict[str, tuple[int, 
         if len(parts) >= 3:
             out.setdefault(f"{parts[0]}:{parts[-1]}", (s, e))
 
-    def _iter_nodes(pdata: dict[str, Any], feat: str) -> list[dict[str, Any]]:
-        out_nodes: list[dict[str, Any]] = []
-        node = pdata.get(feat)
-        if isinstance(node, dict):
-            out_nodes.append(node)
-        insts = pdata.get("instances")
-        if isinstance(insts, dict):
-            for _iid, idata in insts.items():
-                if not isinstance(idata, dict):
-                    continue
-                node2 = idata.get(feat)
-                if isinstance(node2, dict):
-                    out_nodes.append(node2)
-        return out_nodes
-
     for _, pdata in provs.items():
         if not isinstance(pdata, dict):
             continue
         for feat in ("history", "ratings", "watchlist", "playlists"):
-            for node in _iter_nodes(pdata, feat):
-                baseline = node.get("baseline")
-                base: dict[str, Any] = baseline if isinstance(baseline, dict) else node
-                items = base.get("items")
-                if isinstance(items, dict):
-                    iters = items.items()
-                elif isinstance(items, list):
-                    iters = ((it.get("key"), it) for it in items if isinstance(it, dict))
-                else:
-                    continue
-                for k, it in iters:
-                    if not isinstance(it, dict):
-                        continue
+            for node in _iter_feature_nodes(pdata, feat):
+                for k, it in _iter_baseline_items(node):
                     typ = str(it.get("type") or "").strip().lower()
                     if typ != "episode":
                         continue

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -1826,6 +1826,96 @@
       resultsBox.className = "cw-search-results";
       pop.appendChild(resultsBox);
 
+      // Applies a metadata-resolve result's ids onto row/refs. Shared by the picked-result
+      // handler below since the same tmdb-key-rewrite logic is needed in both call sites.
+      function applyResolvedIds(row, refs, ids) {
+        row.raw.ids = row.raw.ids || {};
+
+        if (ids.imdb) {
+          row.imdb = ids.imdb;
+          row.raw.ids.imdb = ids.imdb;
+          refs.imdbIn.value = ids.imdb;
+        }
+        if (ids.tmdb) {
+          const tVal = String(ids.tmdb);
+          row.tmdb = tVal;
+          row.raw.ids.tmdb = ids.tmdb;
+          if (refs.tmdbIn) refs.tmdbIn.value = tVal;
+          const prevKey = (row.key || "").trim();
+          if (!prevKey || /^(tmdb|imdb|trakt|tvdb|slug):/i.test(prevKey)) {
+            row.key = `tmdb:${tVal}`;
+            if (refs.keyIn) refs.keyIn.value = row.key;
+          }
+        }
+        if (ids.trakt) {
+          const trVal = String(ids.trakt);
+          row.trakt = trVal;
+          row.raw.ids.trakt = ids.trakt;
+          if (refs.traktIn) refs.traktIn.value = trVal;
+        }
+      }
+
+      // Applies a picked search result onto row/refs, then resolves and merges full ids.
+      async function applyPickedResult(item) {
+        const picked = item;
+        const newTitle = picked.title || row.title || "";
+        row.title = newTitle;
+        row.raw.title = newTitle || null;
+        refs.titleIn.value = newTitle;
+
+        if (picked.year) {
+          row.year = String(picked.year);
+          row.raw.year = picked.year;
+          refs.yearIn.value = row.year;
+        }
+
+        const wantsAnime = String(typeSelect.value || "").toLowerCase() === "anime";
+        const pickedType = String(picked.type || "movie").toLowerCase();
+
+        const newType = wantsAnime ? "anime" : pickedType;
+        const resolveEntity = wantsAnime ? picked._resolve_entity || pickedType || "movie" : newType;
+
+        row.type = newType;
+        row.raw.type = newType;
+        row.episode = false;
+        updateTypeDisplay(row, refs.typeBtn);
+
+        const tmdbId = picked.tmdb;
+        if (tmdbId != null) {
+          const tmdbStr = String(tmdbId);
+          row.tmdb = tmdbStr;
+          row.raw.ids = row.raw.ids || {};
+          row.raw.ids.tmdb = tmdbId;
+          if (refs.tmdbIn) refs.tmdbIn.value = tmdbStr;
+          const prevKey = (row.key || "").trim();
+          if (!prevKey || /^(tmdb|imdb|trakt|tvdb|slug):/i.test(prevKey)) {
+            row.key = `tmdb:${tmdbStr}`;
+            if (refs.keyIn) refs.keyIn.value = row.key;
+          }
+        }
+
+        if (tmdbId != null) {
+          try {
+            const metaRes = await fetchJSON("/api/metadata/resolve", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ entity: resolveEntity, ids: { tmdb: tmdbId } }),
+            });
+
+            if (metaRes && metaRes.ok && metaRes.result && metaRes.result.ids) {
+              applyResolvedIds(row, refs, metaRes.result.ids || {});
+            }
+          } catch (err) {
+            console.error("metadata resolve failed", err);
+          }
+        }
+
+        markChanged();
+        setStatusSticky("Row updated from metadata", 2500);
+        close();
+        renderRows();
+      }
+
       async function doSearch() {
         const q = (qInput.value || "").trim();
         const yearVal = parseInt(yearInput.value || "", 10);
@@ -1950,89 +2040,7 @@
 
             btn.appendChild(content);
 
-            btn.onclick = async () => {
-              const picked = item;
-              const newTitle = picked.title || row.title || "";
-              row.title = newTitle;
-              row.raw.title = newTitle || null;
-              refs.titleIn.value = newTitle;
-
-              if (picked.year) {
-                row.year = String(picked.year);
-                row.raw.year = picked.year;
-                refs.yearIn.value = row.year;
-              }
-
-              const wantsAnime = String(typeSelect.value || "").toLowerCase() === "anime";
-              const pickedType = String(picked.type || "movie").toLowerCase();
-
-              const newType = wantsAnime ? "anime" : pickedType;
-              const resolveEntity = wantsAnime ? picked._resolve_entity || pickedType || "movie" : newType;
-
-              row.type = newType;
-              row.raw.type = newType;
-              row.episode = false;
-              updateTypeDisplay(row, refs.typeBtn);
-
-              const tmdbId = picked.tmdb;
-              if (tmdbId != null) {
-                const tmdbStr = String(tmdbId);
-                row.tmdb = tmdbStr;
-                row.raw.ids = row.raw.ids || {};
-                row.raw.ids.tmdb = tmdbId;
-                if (refs.tmdbIn) refs.tmdbIn.value = tmdbStr;
-                const prevKey = (row.key || "").trim();
-                if (!prevKey || /^(tmdb|imdb|trakt|tvdb|slug):/i.test(prevKey)) {
-                  row.key = `tmdb:${tmdbStr}`;
-                  if (refs.keyIn) refs.keyIn.value = row.key;
-                }
-              }
-
-              if (tmdbId != null) {
-                try {
-                  const metaRes = await fetchJSON("/api/metadata/resolve", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ entity: resolveEntity, ids: { tmdb: tmdbId } }),
-                  });
-
-                  if (metaRes && metaRes.ok && metaRes.result && metaRes.result.ids) {
-                    const ids = metaRes.result.ids || {};
-                    row.raw.ids = row.raw.ids || {};
-
-                    if (ids.imdb) {
-                      row.imdb = ids.imdb;
-                      row.raw.ids.imdb = ids.imdb;
-                      refs.imdbIn.value = ids.imdb;
-                    }
-                    if (ids.tmdb) {
-                      const tVal = String(ids.tmdb);
-                      row.tmdb = tVal;
-                      row.raw.ids.tmdb = ids.tmdb;
-                      if (refs.tmdbIn) refs.tmdbIn.value = tVal;
-                      const prevKey = (row.key || "").trim();
-                      if (!prevKey || /^(tmdb|imdb|trakt|tvdb|slug):/i.test(prevKey)) {
-                        row.key = `tmdb:${tVal}`;
-                        if (refs.keyIn) refs.keyIn.value = row.key;
-                      }
-                    }
-                    if (ids.trakt) {
-                      const trVal = String(ids.trakt);
-                      row.trakt = trVal;
-                      row.raw.ids.trakt = ids.trakt;
-                      if (refs.traktIn) refs.traktIn.value = trVal;
-                    }
-                  }
-                } catch (err) {
-                  console.error("metadata resolve failed", err);
-                }
-              }
-
-              markChanged();
-              setStatusSticky("Row updated from metadata", 2500);
-              close();
-              renderRows();
-            };
+            btn.onclick = () => applyPickedResult(item);
 
             resultsBox.appendChild(btn);
           });

--- a/assets/js/modals/about.js
+++ b/assets/js/modals/about.js
@@ -15,24 +15,9 @@ const _cwV = (() => {
 const _cwVer = (u) => u + (u.includes("?") ? "&" : "?") + "v=" + encodeURIComponent(String(_cwV));
 
 const { getJson } = await import(_cwVer("./core/net.js"));
-const { escapeHtml, setModalShellInline } = await import(_cwVer("./core/app-auth-setup.js"));
+const { _cmp, _norm, escapeHtml, setModalShellInline } = await import(_cwVer("./core/app-auth-setup.js"));
 
 const cache = { at: 0, data: null, inflight: null };
-
-function _norm(v) {
-  return String(v || "").replace(/^v/i, "").trim();
-}
-
-function _cmp(a, b) {
-  const pa = _norm(a).split(".").map((n) => parseInt(n, 10) || 0);
-  const pb = _norm(b).split(".").map((n) => parseInt(n, 10) || 0);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
-    const da = pa[i] || 0;
-    const db = pb[i] || 0;
-    if (da !== db) return da > db ? 1 : -1;
-  }
-  return 0;
-}
 
 function _providerName(key) {
   const tail = String(key || "").split("_").pop() || key || "-";

--- a/assets/js/modals/core/app-auth-setup.js
+++ b/assets/js/modals/core/app-auth-setup.js
@@ -40,6 +40,21 @@ function _markAuthSetupPending(flag) {
   } catch {}
 }
 
+export function _norm(v) {
+  return String(v || "").replace(/^v/i, "").trim();
+}
+
+export function _cmp(a, b) {
+  const pa = _norm(a).split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = _norm(b).split(".").map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
+    const da = pa[i] || 0;
+    const db = pb[i] || 0;
+    if (da !== db) return da > db ? 1 : -1;
+  }
+  return 0;
+}
+
 export function escapeHtml(s) {
   return String(s || "")
     .replaceAll("&", "&amp;")
@@ -201,4 +216,46 @@ export async function saveRequiredAppAuth({ username, password, setupToken, keep
   _markAuthSetupPending(keepPending);
   try { window.dispatchEvent(new Event("auth-changed")); } catch {}
   return data;
+}
+
+/**
+ * Shared "submit sign-in credentials" flow used by the setup wizard and upgrade-warning
+ * modals: syncs the form into `state`, validates, saves via saveRequiredAppAuth, and on
+ * success resets the password/token fields on `state`. `render` is called after every
+ * state change except on success, where callers differ (e.g. closing the modal vs moving
+ * to another step) - `onSuccess` owns rendering (and any other state changes) for that case.
+ *
+ * @param {HTMLElement} hostEl - modal host element the auth fields live in
+ * @param {object} state - mutable modal state (username/password/password2/setup_token/error/saving)
+ * @param {() => void} render - re-renders the modal from current state
+ * @param {() => void|Promise<void>} onSuccess - called once the shared fields are reset after a successful save
+ */
+export async function submitAppAuthCredentials(hostEl, state, render, onSuccess) {
+  syncAppAuthState(hostEl, state);
+  state.error = validateAppAuthState(state);
+  if (state.error) {
+    render();
+    return;
+  }
+
+  state.saving = true;
+  render();
+
+  try {
+    await saveRequiredAppAuth({
+      username: state.username,
+      password: state.password,
+      setupToken: state.setup_token,
+    });
+    state.saving = false;
+    state.error = "";
+    state.password = "";
+    state.password2 = "";
+    state.setup_token = "";
+    await onSuccess();
+  } catch (err) {
+    state.saving = false;
+    state.error = String(err?.message || "Failed to save sign-in settings.");
+    render();
+  }
 }

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -1531,6 +1531,33 @@ left.innerHTML = `
   }
 }
 
+// Builds the 8-field state.globals payload from the Globals panel's DOM fields, given the
+// already-computed drop-guard/suspect-percent/blackbox inputs (their derivation differs
+// slightly between the "input" and "change" handlers in bindChangeHandlers below).
+function collectGlobals(dropOn,minPrev,pct,bb){
+  return {
+    dry_run:!!Q("#gl-dry")?.checked,
+    verify_after_write:!!Q("#gl-verify")?.checked,
+    drop_guard:dropOn,
+    allow_mass_delete:!!Q("#gl-mass")?.checked && !dropOn,
+    tombstone_ttl_days:parseInt(Q("#gl-ttl")?.value||"0",10)||0,
+    include_observed_deletes:!!Q("#gl-observed")?.checked,
+    runtime:{suspect_min_prev:minPrev,suspect_shrink_ratio:pct/100},
+    blackbox:bb
+  };
+}
+
+// Reads the jellyfin/emby watchlist-mode fields for the given id prefix ("jf"/"em"); the
+// query/delay/guid fields (cx-wl-*) are shared between both providers.
+function readServerWatchlist(prefix){
+  const mode=ID(`cx-${prefix}-wl-mode-pl`)?.checked?"playlist":ID(`cx-${prefix}-wl-mode-col`)?.checked?"collection":"favorites";
+  const name=(ID(`cx-${prefix}-wl-pl-name`)?.value||"").trim()||"Watchlist";
+  const q=parseInt(ID("cx-wl-q")?.value||"25",10)||25;
+  const d=parseInt(ID("cx-wl-delay")?.value||"0",10)||0;
+  const gp=(ID("cx-wl-guid")?.value||"").split(",").map(s=>s.trim()).filter(Boolean);
+  return {mode,playlist_name:name,watchlist_query_limit:q,watchlist_write_delay_ms:d,watchlist_guid_priority:gp.length?gp:undefined};
+}
+
 function bindChangeHandlers(state,root){
   const syncGlobalsUI = () => {
     const drop = ID("gl-drop");
@@ -1572,16 +1599,7 @@ function bindChangeHandlers(state,root){
       const vp=ID("gl-sus-pct-val"); if(vp) vp.textContent=String(pct);
       const vm=ID("gl-sus-min-val"); if(vm) vm.textContent=String(minPrev);
 
-      state.globals=Object.assign({},state.globals,{
-        dry_run:!!Q("#gl-dry")?.checked,
-        verify_after_write:!!Q("#gl-verify")?.checked,
-        drop_guard:dropOn,
-        allow_mass_delete:!!Q("#gl-mass")?.checked && !dropOn,
-        tombstone_ttl_days:parseInt(Q("#gl-ttl")?.value||"0",10)||0,
-        include_observed_deletes:!!Q("#gl-observed")?.checked,
-        runtime:{suspect_min_prev:minPrev,suspect_shrink_ratio:pct/100},
-        blackbox:bb
-      });
+      state.globals=Object.assign({},state.globals,collectGlobals(dropOn,minPrev,pct,bb));
       const adv=ID("gl-drop-adv");
       if(adv){adv.style.opacity=dropOn?"":"0.5";adv.style.pointerEvents=dropOn?"auto":"none"}
     }
@@ -1848,37 +1866,15 @@ function bindChangeHandlers(state,root){
       const adv=ID("gl-drop-adv");
       if(adv){adv.style.opacity=dropOn?"":"0.5";adv.style.pointerEvents=dropOn?"auto":"none"}
 
-      state.globals={
-        dry_run:!!Q("#gl-dry")?.checked,
-        verify_after_write:!!Q("#gl-verify")?.checked,
-        drop_guard:dropOn,
-        allow_mass_delete:!!Q("#gl-mass")?.checked && !dropOn,
-        tombstone_ttl_days:parseInt(Q("#gl-ttl")?.value||"0",10)||0,
-        include_observed_deletes:!!Q("#gl-observed")?.checked,
-        runtime:{suspect_min_prev:minPrev,suspect_shrink_ratio:pct/100},
-        blackbox:bb
-      };
+      state.globals=collectGlobals(dropOn,minPrev,pct,bb);
     }
 
-    if(id==="cx-jf-wl-mode-fav"||id==="cx-jf-wl-mode-pl"||id==="cx-jf-wl-mode-col"||id==="cx-jf-wl-pl-name"||id==="cx-wl-q"||id==="cx-wl-delay"||id==="cx-wl-guid"){
-      const jf=state.jellyfin||(state.jellyfin={});
-      const mode=ID("cx-jf-wl-mode-pl")?.checked?"playlist":ID("cx-jf-wl-mode-col")?.checked?"collection":"favorites";
-      const name=(ID("cx-jf-wl-pl-name")?.value||"").trim()||"Watchlist";
-      const q=parseInt(ID("cx-wl-q")?.value||"25",10)||25;
-      const d=parseInt(ID("cx-wl-delay")?.value||"0",10)||0;
-      const gp=(ID("cx-wl-guid")?.value||"").split(",").map(s=>s.trim()).filter(Boolean);
-      jf.watchlist={mode,playlist_name:name,watchlist_query_limit:q,watchlist_write_delay_ms:d,watchlist_guid_priority:gp.length?gp:undefined};
-    }
-
-    if(id==="cx-em-wl-mode-fav"||id==="cx-em-wl-mode-pl"||id==="cx-em-wl-mode-col"||id==="cx-em-wl-pl-name"||id==="cx-wl-q"||id==="cx-wl-delay"||id==="cx-wl-guid"){
-      const em=state.emby||(state.emby={});
-      const mode=ID("cx-em-wl-mode-pl")?.checked?"playlist":ID("cx-em-wl-mode-col")?.checked?"collection":"favorites";
-      const name=(ID("cx-em-wl-pl-name")?.value||"").trim()||"Watchlist";
-      const q=parseInt(ID("cx-wl-q")?.value||"25",10)||25;
-      const d=parseInt(ID("cx-wl-delay")?.value||"0",10)||0;
-      const gp=(ID("cx-wl-guid")?.value||"").split(",").map(s=>s.trim()).filter(Boolean);
-      em.watchlist={mode,playlist_name:name,watchlist_query_limit:q,watchlist_write_delay_ms:d,watchlist_guid_priority:gp.length?gp:undefined};
-    }
+    [["jellyfin","jf"],["emby","em"]].forEach(([providerKey,prefix])=>{
+      if(id===`cx-${prefix}-wl-mode-fav`||id===`cx-${prefix}-wl-mode-pl`||id===`cx-${prefix}-wl-mode-col`||id===`cx-${prefix}-wl-pl-name`||id==="cx-wl-q"||id==="cx-wl-delay"||id==="cx-wl-guid"){
+        const target=state[providerKey]||(state[providerKey]={});
+        target.watchlist=readServerWatchlist(prefix);
+      }
+    });
 
     if(id==="cx-pmdb-wl-name"){
       state.pairProviders=state.pairProviders||{};

--- a/assets/js/modals/setup-wizard/index.js
+++ b/assets/js/modals/setup-wizard/index.js
@@ -13,18 +13,14 @@ const _cwVer = (u) => u + (u.includes("?") ? "&" : "?") + "v=" + encodeURICompon
 const {
   appAuthFormCss,
   escapeHtml,
-  saveRequiredAppAuth,
   setModalDismissible,
   setModalShellInline,
+  submitAppAuthCredentials,
   syncAppAuthState,
-  validateAppAuthState,
   wireLiveAppAuthValidation,
   renderAppAuthFields,
+  _norm,
 } = await import(_cwVer("../core/app-auth-setup.js"));
-
-function _norm(v) {
-  return String(v || "").replace(/^v/i, "").trim();
-}
 
 function _collapseByDefault() {
   const ids = ["sec-auth", "sec-meta", "sec-sync", "sec-scrobbler", "sc-sec-webhook", "sc-sec-watch"];
@@ -151,28 +147,8 @@ export default {
 
     setModalDismissible(false);
 
-    async function submitCredentials(btn) {
-      syncAppAuthState(hostEl, state);
-      state.error = validateAppAuthState(state);
-      if (state.error) {
-        render();
-        return;
-      }
-
-      state.saving = true;
-      render();
-
-      try {
-        await saveRequiredAppAuth({
-          username: state.username,
-          password: state.password,
-          setupToken: state.setup_token,
-        });
-        state.saving = false;
-        state.error = "";
-        state.password = "";
-        state.password2 = "";
-        state.setup_token = "";
+    async function submitCredentials() {
+      await submitAppAuthCredentials(hostEl, state, render, async () => {
         try { window.notify?.("Sign-in enabled."); } catch {}
         try {
           const boot = window.__cwAuthBootstrapState || {};
@@ -183,12 +159,7 @@ export default {
           try { _openSettings(); } catch {}
           try { window.cwSettingsSelect?.("overview"); } catch {}
         }, 0);
-        return;
-      } catch (err) {
-        state.error = String(err?.message || "Failed to save sign-in settings.");
-        state.saving = false;
-        render();
-      }
+      });
     }
 
     function renderIntro() {
@@ -306,9 +277,9 @@ export default {
       }
       const saveBtn = hostEl.querySelector('[data-x="save"]');
       wireLiveAppAuthValidation(hostEl, state, "sw-auth-error", saveBtn);
-      saveBtn?.addEventListener("click", (e) => submitCredentials(e.currentTarget));
+      saveBtn?.addEventListener("click", () => submitCredentials());
       hostEl.querySelector("#sw-auth-pass2")?.addEventListener("keydown", (e) => {
-        if (e.key === "Enter" && !state.saving) submitCredentials(hostEl.querySelector('[data-x="save"]'));
+        if (e.key === "Enter" && !state.saving) submitCredentials();
       });
     }
 

--- a/assets/js/modals/upgrade-warning/index.js
+++ b/assets/js/modals/upgrade-warning/index.js
@@ -12,33 +12,19 @@ const _cwVer = (u) => u + (u.includes("?") ? "&" : "?") + "v=" + encodeURICompon
 const { getJson, postJson } = await import(_cwVer("../core/net.js"));
 const { renderNotesMarkup } = await import(_cwVer("./notes.js"));
 const {
+  _cmp,
+  _norm,
   appAuthFormCss,
   escapeHtml,
   fetchAppAuthStatus,
   hasEnabledAppAuth,
   renderAppAuthFields,
-  saveRequiredAppAuth,
   setModalDismissible,
   setModalShellInline,
+  submitAppAuthCredentials,
   syncAppAuthState,
-  validateAppAuthState,
   wireLiveAppAuthValidation,
 } = await import(_cwVer("../core/app-auth-setup.js"));
-
-function _norm(v) {
-  return String(v || "").replace(/^v/i, "").trim();
-}
-
-function _cmp(a, b) {
-  const pa = _norm(a).split(".").map((n) => parseInt(n, 10) || 0);
-  const pb = _norm(b).split(".").map((n) => parseInt(n, 10) || 0);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
-    const da = pa[i] || 0;
-    const db = pb[i] || 0;
-    if (da !== db) return da > db ? 1 : -1;
-  }
-  return 0;
-}
 
 async function _runConfigMigration() {
   return postJson("/api/config/migrate");
@@ -190,40 +176,15 @@ export default {
     }
 
     async function submitCredentials() {
-      syncAppAuthState(hostEl, state);
-      state.error = validateAppAuthState(state);
-      if (state.error) {
-        render();
-        return;
-      }
-
-      state.saving = true;
-      render();
-
-      try {
-        await saveRequiredAppAuth({
-          username: state.username,
-          password: state.password,
-          setupToken: state.setup_token,
-        });
+      await submitAppAuthCredentials(hostEl, state, render, async () => {
         state.authReady = true;
-        state.saving = false;
-        state.error = "";
-        state.password = "";
-        state.password2 = "";
-        state.setup_token = "";
         state.step = requiresCleanReset ? "cleanup" : "migrate";
         notify(requiresCleanReset
           ? "Sign-in saved. You can now run the clean reset."
           : "Sign-in saved. CrossWatch is updating the config in the background.");
         render();
         if (!requiresCleanReset) ensureAutoSaved();
-        return;
-      } catch (err) {
-        state.saving = false;
-        state.error = String(err?.message || "Failed to save sign-in settings.");
-        render();
-      }
+      });
     }
 
     function layout(body, foot) {

--- a/assets/js/modals/upgrade-warning/notes.js
+++ b/assets/js/modals/upgrade-warning/notes.js
@@ -1,11 +1,11 @@
-function escapeHtml(s) {
-  return String(s || "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
+const _cwV = (() => {
+  try { return new URL(import.meta.url).searchParams.get("v") || window.__CW_VERSION__ || Date.now(); }
+  catch { return window.__CW_VERSION__ || Date.now(); }
+})();
+
+const _cwVer = (u) => u + (u.includes("?") ? "&" : "?") + "v=" + encodeURIComponent(String(_cwV));
+
+const { escapeHtml } = await import(_cwVer("../core/app-auth-setup.js"));
 
 function renderInlineMarkup(text) {
   const linkLabel = (url) => {

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -482,11 +482,9 @@ serverUUID: async (instanceId) => {
     },
   };
 
-  async function persistConfigPaths(pairs, noteId) {
+  // POSTs cfg to /api/config; on failure logs + surfaces noteId and returns false (never throws).
+  async function saveConfig(cfg, noteId, warnLabel = "save failed") {
     try {
-      const serverCfg = await API.cfgGet();
-      const cfg = typeof structuredClone === "function" ? structuredClone(serverCfg || {}) : JSON.parse(JSON.stringify(serverCfg || {}));
-      for (const [path, value] of pairs || []) deepSet(cfg, String(path || ""), value);
       const r = await fetch("/api/config", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -494,6 +492,20 @@ serverUUID: async (instanceId) => {
         body: JSON.stringify(cfg),
       });
       if (!r.ok) throw new Error(`POST /api/config ${r.status}`);
+      return true;
+    } catch (e) {
+      console.warn(`[scrobbler] ${warnLabel}:`, e);
+      if (noteId) setNote(noteId, "Couldn't save settings. Hit Save or check logs.", "err");
+      return false;
+    }
+  }
+
+  async function persistConfigPaths(pairs, noteId) {
+    try {
+      const serverCfg = await API.cfgGet();
+      const cfg = typeof structuredClone === "function" ? structuredClone(serverCfg || {}) : JSON.parse(JSON.stringify(serverCfg || {}));
+      for (const [path, value] of pairs || []) deepSet(cfg, String(path || ""), value);
+      await saveConfig(cfg, noteId);
     } catch (e) {
       console.warn("[scrobbler] save failed:", e);
       if (noteId) setNote(noteId, "Couldn't save settings. Hit Save or check logs.", "err");
@@ -509,13 +521,7 @@ serverUUID: async (instanceId) => {
       cfg.plex = Object.assign({}, cfg.plex || {}, rootPatch.plex || {});
       cfg.emby = Object.assign({}, cfg.emby || {}, rootPatch.emby || {});
       cfg.jellyfin = Object.assign({}, cfg.jellyfin || {}, rootPatch.jellyfin || {});
-      const r = await fetch("/api/config", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        cache: "no-store",
-        body: JSON.stringify(cfg),
-      });
-      if (!r.ok) throw new Error(`POST /api/config ${r.status}`);
+      await saveConfig(cfg, noteId);
     } catch (e) {
       console.warn("[scrobbler] save failed:", e);
       if (noteId) setNote(noteId, "Couldn't save settings. Hit Save or check logs.", "err");
@@ -1170,31 +1176,43 @@ try {
     applyModeDisable();
   }
 
-  function ensureRouteOptionsModal() {
-    if (STATE.routeOptionsModal?.overlay?.isConnected) return STATE.routeOptionsModal;
+  // Shared "gradient box" panel styles reused across the route options/filters modals.
+  const ROUTE_MODAL_NOTE_STYLE = "margin:0 0 14px;padding:12px 14px;border-radius:16px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.018))";
+  const ROUTE_MODAL_FIELD_BOX_STYLE = "display:grid;gap:10px;padding:16px 18px;border-radius:18px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.015))";
 
+  // Builds the shared overlay/card/head/close scaffolding used by the route options and
+  // route filters modals. Callers append their own content into `card` and wire `close`.
+  function buildRouteModalShell({ title: titleText, width, subtitleMaxWidth }) {
     const overlay = el("div", {
       className: "sc-route-modal hidden",
       style: "position:fixed;inset:0;z-index:10000;background:rgba(4,7,14,.62);backdrop-filter:blur(8px);display:flex;align-items:center;justify-content:center;padding:20px",
     });
     const card = el("div", {
       className: "sc-route-modal-card",
-      style: "width:min(560px,calc(100vw - 32px));max-height:min(88vh,820px);overflow:auto;border-radius:22px;background:linear-gradient(180deg,rgba(12,14,23,.98),rgba(6,8,12,.99));border:1px solid rgba(255,255,255,.10);box-shadow:0 24px 60px rgba(0,0,0,.45);padding:18px 18px 16px",
+      style: `width:min(${width},calc(100vw - 32px));max-height:min(88vh,820px);overflow:auto;border-radius:22px;background:linear-gradient(180deg,rgba(12,14,23,.98),rgba(6,8,12,.99));border:1px solid rgba(255,255,255,.10);box-shadow:0 24px 60px rgba(0,0,0,.45);padding:18px 18px 16px`,
     });
     overlay.appendChild(card);
 
     const head = el("div", { style: "display:flex;align-items:flex-start;gap:12px;justify-content:space-between;margin-bottom:14px" });
     const headText = el("div", { style: "display:grid;gap:6px" });
-    const title = el("div", { style: "font-size:20px;font-weight:900;color:#f4f7ff", textContent: "Route Options" });
-    const subtitle = el("div", { className: "micro-note", style: "max-width:420px" });
+    const title = el("div", { style: "font-size:20px;font-weight:900;color:#f4f7ff", textContent: titleText });
+    const subtitle = el("div", { className: "micro-note", style: `max-width:${subtitleMaxWidth}` });
     headText.append(title, subtitle);
     const close = el("button", { type: "button", className: "btn small", textContent: "Close" });
     head.append(headText, close);
     card.appendChild(head);
 
+    return { overlay, card, head, headText, title, subtitle, close };
+  }
+
+  function ensureRouteOptionsModal() {
+    if (STATE.routeOptionsModal?.overlay?.isConnected) return STATE.routeOptionsModal;
+
+    const { overlay, card, title, subtitle, close } = buildRouteModalShell({ title: "Route Options", width: "560px", subtitleMaxWidth: "420px" });
+
     const defaultsNote = el("div", {
       className: "micro-note",
-      style: "margin:0 0 14px;padding:12px 14px;border-radius:16px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.018))",
+      style: ROUTE_MODAL_NOTE_STYLE,
     });
     card.appendChild(defaultsNote);
 
@@ -1444,37 +1462,20 @@ try {
   function ensureRouteFiltersModal() {
     if (STATE.routeFiltersModal?.overlay?.isConnected) return STATE.routeFiltersModal;
 
-    const overlay = el("div", {
-      className: "sc-route-modal hidden",
-      style: "position:fixed;inset:0;z-index:10000;background:rgba(4,7,14,.62);backdrop-filter:blur(8px);display:flex;align-items:center;justify-content:center;padding:20px",
-    });
-    const card = el("div", {
-      className: "sc-route-modal-card",
-      style: "width:min(1080px,calc(100vw - 32px));max-height:min(88vh,820px);overflow:auto;border-radius:22px;background:linear-gradient(180deg,rgba(12,14,23,.98),rgba(6,8,12,.99));border:1px solid rgba(255,255,255,.10);box-shadow:0 24px 60px rgba(0,0,0,.45);padding:18px 18px 16px",
-    });
-    overlay.appendChild(card);
-
-    const head = el("div", { style: "display:flex;align-items:flex-start;gap:12px;justify-content:space-between;margin-bottom:14px" });
-    const headText = el("div", { style: "display:grid;gap:6px" });
-    const title = el("div", { style: "font-size:20px;font-weight:900;color:#f4f7ff", textContent: "Route Filters" });
-    const subtitle = el("div", { className: "micro-note", style: "max-width:480px" });
-    headText.append(title, subtitle);
-    const close = el("button", { type: "button", className: "btn small", textContent: "Close" });
-    head.append(headText, close);
-    card.appendChild(head);
+    const { overlay, card, title, subtitle, close } = buildRouteModalShell({ title: "Route Filters", width: "1080px", subtitleMaxWidth: "480px" });
 
     const note = el("div", {
       className: "micro-note",
-      style: "margin:0 0 14px;padding:12px 14px;border-radius:16px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.018))",
+      style: ROUTE_MODAL_NOTE_STYLE,
       textContent: "Filters are route-specific. Only playback that matches this route's filters will be scrobbled through this route.",
     });
     card.appendChild(note);
 
     const grid = el("div", { className: "sc-route-filter-grid", style: "display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:16px" });
-    const namesBox = el("div", { style: "display:grid;gap:10px;padding:16px 18px;border-radius:18px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.015))" });
-    const idBox = el("div", { style: "display:grid;gap:10px;padding:16px 18px;border-radius:18px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.015))" });
-    const uuidAllowBox = el("div", { style: "display:grid;gap:10px;padding:16px 18px;border-radius:18px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.015))" });
-    const uuidBlockBox = el("div", { style: "display:grid;gap:10px;padding:16px 18px;border-radius:18px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.015))" });
+    const namesBox = el("div", { style: ROUTE_MODAL_FIELD_BOX_STYLE });
+    const idBox = el("div", { style: ROUTE_MODAL_FIELD_BOX_STYLE });
+    const uuidAllowBox = el("div", { style: ROUTE_MODAL_FIELD_BOX_STYLE });
+    const uuidBlockBox = el("div", { style: ROUTE_MODAL_FIELD_BOX_STYLE });
     grid.append(namesBox, idBox, uuidAllowBox, uuidBlockBox);
     card.appendChild(grid);
 
@@ -1980,6 +1981,33 @@ function chip(text, onRemove, onClick) {
     return `<div class="field"><label for="${id}">${label}</label>${helpBtn(tipId)}<input id="${id}" class="input" type="number" inputmode="numeric" min="${min}" max="${max}" step="${step}" placeholder="${placeholder}"></div>`;
   }
 
+  // Wires a sub-tile/sub-panel tab group under `root`: click-to-select, active-state
+  // toggling, and localStorage persistence keyed by `storageKey`. `normalize(sub)` maps
+  // a raw sub id (or undefined) to the canonical tab id, including the default tab.
+  // Returns the selectTab(sub, {persist}) function.
+  function wireSubTabs(root, storageKey, normalize) {
+    const selectTab = (sub, opts = {}) => {
+      const want = normalize(sub);
+      root.querySelectorAll('.cw-subtile[data-sub]').forEach((btn) => {
+        btn.classList.toggle("active", (btn.dataset.sub || "").toLowerCase() === want);
+      });
+      root.querySelectorAll('.cw-subpanel[data-sub]').forEach((sp) => {
+        sp.classList.toggle("active", (sp.dataset.sub || "").toLowerCase() === want);
+      });
+      if (opts.persist !== false) {
+        try { localStorage.setItem(storageKey, want); } catch {}
+      }
+    };
+
+    root.querySelectorAll('.cw-subtile[data-sub]').forEach((btn) => {
+      btn.addEventListener("click", () => selectTab(btn.dataset.sub));
+    });
+
+    try { selectTab(localStorage.getItem(storageKey), { persist: false }); } catch { selectTab(undefined, { persist: false }); }
+
+    return selectTab;
+  }
+
   function buildUI() {
     injectStyles();
 
@@ -1992,25 +2020,7 @@ function chip(text, onRemove, onClick) {
       // Tabs: Plex / Jellyfin / Emby / Advanced
       const tabKey = "cw.ui.scrobbler.webhook.tab.v1";
       const root = STATE.webhookHost;
-      const selectTab = (sub, opts = {}) => {
-        const want = (sub || "plex").toLowerCase();
-        root.querySelectorAll('.cw-subtile[data-sub]').forEach((btn) => {
-          btn.classList.toggle("active", (btn.dataset.sub || "").toLowerCase() === want);
-        });
-        root.querySelectorAll('.cw-subpanel[data-sub]').forEach((sp) => {
-          sp.classList.toggle("active", (sp.dataset.sub || "").toLowerCase() === want);
-        });
-        if (opts.persist !== false) {
-          try { localStorage.setItem(tabKey, want); } catch {}
-        }
-      };
-      STATE._watcherSelectTab = selectTab;
-
-      root.querySelectorAll('.cw-subtile[data-sub]').forEach((btn) => {
-        btn.addEventListener("click", () => selectTab(btn.dataset.sub || "plex"));
-      });
-
-      try { selectTab(localStorage.getItem(tabKey) || "plex", { persist: false }); } catch { selectTab("plex", { persist: false }); }
+      STATE._watcherSelectTab = wireSubTabs(root, tabKey, (sub) => (sub || "plex").toLowerCase());
     }
 
     if (STATE.watcherHost) {
@@ -2029,28 +2039,10 @@ function chip(text, onRemove, onClick) {
       // Tabs: Watcher / Advanced
       const tabKey = "cw.ui.scrobbler.watcher.tab.v1";
       const root = STATE.watcherHost;
-      const selectTab = (sub, opts = {}) => {
+      STATE._watcherSelectTab = wireSubTabs(root, tabKey, (sub) => {
         const raw = (sub || "watcher").toLowerCase();
-        const want = raw === "advanced" ? "advanced" : "watcher";
-        root.querySelectorAll('.cw-subtile[data-sub]').forEach((btn) => {
-          btn.classList.toggle("active", (btn.dataset.sub || "").toLowerCase() === want);
-        });
-        root.querySelectorAll('.cw-subpanel[data-sub]').forEach((sp) => {
-          sp.classList.toggle("active", (sp.dataset.sub || "").toLowerCase() === want);
-        });
-        if (opts.persist !== false) {
-          try { localStorage.setItem(tabKey, want); } catch {}
-        }
-      };
-      STATE._watcherSelectTab = selectTab;
-
-
-      root.querySelectorAll('.cw-subtile[data-sub]').forEach((btn) => {
-        btn.addEventListener("click", () => selectTab(btn.dataset.sub || "watcher"));
+        return raw === "advanced" ? "advanced" : "watcher";
       });
-
-      try { selectTab(localStorage.getItem(tabKey) || "watcher", { persist: false }); } catch { selectTab("watcher", { persist: false }); }
-
     }
 
     bindHelpTips(STATE.mount || d);
@@ -2697,13 +2689,8 @@ function chip(text, onRemove, onClick) {
     cfg.emby = Object.assign({}, cfg.emby || {}, rootPatch.emby || {});
     cfg.jellyfin = Object.assign({}, cfg.jellyfin || {}, rootPatch.jellyfin || {});
 
-    const r = await fetch("/api/config", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      cache: "no-store",
-      body: JSON.stringify(cfg),
-    });
-    if (!r.ok) throw new Error(`POST /api/config ${r.status}`);
+    const ok = await saveConfig(cfg, "sc-pms-note", "pre-start save failed");
+    if (!ok) return;
 
     w._cfgCache = cfg;
     STATE.cfg = cfg;

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -110,27 +110,25 @@ RUNNING_PROCS: Dict[str, threading.Thread] = {}
 SYNC_PROC_LOCK = threading.Lock()
 
 # Debug helpers
-def _is_http_debug_enabled() -> bool:
+def _cached_runtime_flag(cache: Dict[str, Any], key: str) -> bool:
+    """TTL-cached (2s) read of cfg["runtime"][key] as a bool. `cache` is one of the
+    per-flag dicts below ({"ts": ..., "val": ...}); shared by the debug/debug_http/
+    debug_mods flag readers, which differ only in which cache dict and config key they use."""
     try:
         now = time.time()
-        if now - _DEBUG_HTTP_CACHE["ts"] > 2.0:
+        if now - cache["ts"] > 2.0:
             cfg = load_config()
-            _DEBUG_HTTP_CACHE["val"] = bool(((cfg.get("runtime") or {}).get("debug_http") or False))
-            _DEBUG_HTTP_CACHE["ts"] = now
-        return _DEBUG_HTTP_CACHE["val"]
+            cache["val"] = bool(((cfg.get("runtime") or {}).get(key) or False))
+            cache["ts"] = now
+        return cache["val"]
     except Exception:
         return False
 
+def _is_http_debug_enabled() -> bool:
+    return _cached_runtime_flag(_DEBUG_HTTP_CACHE, "debug_http")
+
 def _is_debug_enabled() -> bool:
-    try:
-        now = time.time()
-        if now - _DEBUG_CACHE["ts"] > 2.0:
-            cfg = load_config()
-            _DEBUG_CACHE["val"] = bool(((cfg.get("runtime") or {}).get("debug") or False))
-            _DEBUG_CACHE["ts"] = now
-        return _DEBUG_CACHE["val"]
-    except Exception:
-        return False
+    return _cached_runtime_flag(_DEBUG_CACHE, "debug")
 
 
 def _resolve_config_scoped_path(raw_path: str) -> Path:
@@ -320,15 +318,7 @@ def _redact_secrets_in_text(s: str) -> str:
     return out
 
 def _is_mods_debug_enabled() -> bool:
-    try:
-        now = time.time()
-        if now - _DEBUG_MODS_CACHE["ts"] > 2.0:
-            cfg = load_config()
-            _DEBUG_MODS_CACHE["val"] = bool(((cfg.get("runtime") or {}).get("debug_mods") or False))
-            _DEBUG_MODS_CACHE["ts"] = now
-        return _DEBUG_MODS_CACHE["val"]
-    except Exception:
-        return False
+    return _cached_runtime_flag(_DEBUG_MODS_CACHE, "debug_mods")
 
 def _apply_debug_env_from_config() -> None:
     on = _is_mods_debug_enabled()

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -1005,6 +1005,41 @@ def _ensure_dict(parent: dict[str, Any], key: str) -> dict[str, Any]:
     return d
 
 
+def _normalize_rate_limit(
+    block: dict[str, Any],
+    post_default: float,
+    get_default: float,
+    *,
+    post_max: float = 1000.0,
+    get_max: float = 1000.0,
+) -> dict[str, Any]:
+    """Normalize the ``rate_limit`` sub-block of a provider config in place.
+
+    Coerces ``post_per_sec``/``get_per_sec`` to floats (falling back to their
+    defaults on bad input), clamps them to ``[0, post_max]``/``[0, get_max]``
+    (0 disables throttling), and collapses whole-number floats to ``int``.
+    """
+    rl = _ensure_dict(block, "rate_limit")
+
+    def _rate(name: str, default: float, max_v: float) -> float:
+        v = rl.get(name, default)
+        try:
+            f = float(v)
+        except Exception:
+            f = float(default)
+        if f < 0:
+            f = 0.0
+        if f > max_v:
+            f = max_v
+        return f
+
+    post_rps = _rate("post_per_sec", post_default, post_max)
+    get_rps = _rate("get_per_sec", get_default, get_max)
+    rl["post_per_sec"] = int(post_rps) if float(post_rps).is_integer() else float(post_rps)
+    rl["get_per_sec"] = int(get_rps) if float(get_rps).is_integer() else float(get_rps)
+    return rl
+
+
 def _normalize_tmdb_sync(cfg: dict[str, Any]) -> None:
     t0 = cfg.get("tmdb_sync")
     if isinstance(t0, dict):
@@ -1065,80 +1100,17 @@ def _tmdb_api_key(cfg: dict[str, Any]) -> str:
 
 
 def _normalize_trakt(cfg: dict[str, Any]) -> None:
-    t0 = cfg.get("trakt")
-    if isinstance(t0, dict):
-        t = t0
-    else:
-        t = {}
-        cfg["trakt"] = t
-
-    rl0 = t.get("rate_limit")
-    if isinstance(rl0, dict):
-        rl = rl0
-    else:
-        rl = {}
-        t["rate_limit"] = rl
-
-    def _rate(name: str, default: float, *, max_v: float = 1000.0) -> float:
-        v = rl.get(name, default)
-        try:
-            f = float(v)
-        except Exception:
-            f = float(default)
-        if f < 0:
-            f = 0.0
-        if f > max_v:
-            f = max_v
-        return f
-
-    # Allow 0 to disable throttling.
-    post_rps = _rate("post_per_sec", 1.0)
-    get_rps = _rate("get_per_sec", 3.33)
-    rl["post_per_sec"] = int(post_rps) if float(post_rps).is_integer() else float(post_rps)
-    rl["get_per_sec"] = int(get_rps) if float(get_rps).is_integer() else float(get_rps)
+    t = _ensure_dict(cfg, "trakt")
+    _normalize_rate_limit(t, 1.0, 3.33)
 
 
 def _normalize_simkl(cfg: dict[str, Any]) -> None:
-    s0 = cfg.get("simkl")
-    if isinstance(s0, dict):
-        s = s0
-    else:
-        s = {}
-        cfg["simkl"] = s
-
-    rl0 = s.get("rate_limit")
-    if isinstance(rl0, dict):
-        rl = rl0
-    else:
-        rl = {}
-        s["rate_limit"] = rl
-
-    def _rate(name: str, default: float, *, max_v: float = 1000.0) -> float:
-        v = rl.get(name, default)
-        try:
-            f = float(v)
-        except Exception:
-            f = float(default)
-        if f < 0:
-            f = 0.0
-        if f > max_v:
-            f = max_v
-        return f
-
-    # Allow 0 to disable throttling.
-    post_rps = _rate("post_per_sec", 1.0)
-    get_rps = _rate("get_per_sec", 10.0)
-    rl["post_per_sec"] = int(post_rps) if float(post_rps).is_integer() else float(post_rps)
-    rl["get_per_sec"] = int(get_rps) if float(get_rps).is_integer() else float(get_rps)
+    s = _ensure_dict(cfg, "simkl")
+    _normalize_rate_limit(s, 1.0, 10.0)
 
 
 def _normalize_mdblist(cfg: dict[str, Any]) -> None:
-    m0 = cfg.get("mdblist")
-    if isinstance(m0, dict):
-        m = m0
-    else:
-        m = {}
-        cfg["mdblist"] = m
+    m = _ensure_dict(cfg, "mdblist")
 
     def _norm_method(block: dict[str, Any]) -> str:
         has_api = bool(str(block.get("api_key") or block.get("key") or "").strip())
@@ -1211,39 +1183,11 @@ def _normalize_mdblist(cfg: dict[str, Any]) -> None:
             if isinstance(inst, dict):
                 _normalize_auth_block(inst)
 
-    rl0 = m.get("rate_limit")
-    if isinstance(rl0, dict):
-        rl = rl0
-    else:
-        rl = {}
-        m["rate_limit"] = rl
-
-    def _rate(name: str, default: float, *, max_v: float = 1000.0) -> float:
-        v = rl.get(name, default)
-        try:
-            f = float(v)
-        except Exception:
-            f = float(default)
-        if f < 0:
-            f = 0.0
-        if f > max_v:
-            f = max_v
-        return f
-
-    # Allow 0 to disable throttling.
-    post_rps = _rate("post_per_sec", 1.0)
-    get_rps = _rate("get_per_sec", 10.0)
-    rl["post_per_sec"] = int(post_rps) if float(post_rps).is_integer() else float(post_rps)
-    rl["get_per_sec"] = int(get_rps) if float(get_rps).is_integer() else float(get_rps)
+    _normalize_rate_limit(m, 1.0, 10.0)
 
 
 def _normalize_publicmetadb(cfg: dict[str, Any]) -> None:
-    p0 = cfg.get("publicmetadb")
-    if isinstance(p0, dict):
-        p = p0
-    else:
-        p = {}
-        cfg["publicmetadb"] = p
+    p = _ensure_dict(cfg, "publicmetadb")
     p["base_url"] = str(p.get("base_url") or "https://publicmetadb.com").strip().rstrip("/")
     p["watchlist_name"] = str(p.get("watchlist_name") or "Watchlist").strip() or "Watchlist"
     p["watchlist_auto_create"] = bool(p.get("watchlist_auto_create", True))
@@ -1264,29 +1208,7 @@ def _normalize_publicmetadb(cfg: dict[str, Any]) -> None:
     _int_range("ratings_update_per_hour", 100, 1, 100)
     p["ratings_label"] = str(p.get("ratings_label") or "Overall").strip() or "Overall"
 
-    rl0 = p.get("rate_limit")
-    if isinstance(rl0, dict):
-        rl = rl0
-    else:
-        rl = {}
-        p["rate_limit"] = rl
-
-    def _rate(name: str, default: float, *, max_v: float) -> float:
-        v = rl.get(name, default)
-        try:
-            f = float(v)
-        except Exception:
-            f = float(default)
-        if f < 0:
-            f = 0.0
-        if f > max_v:
-            f = max_v
-        return f
-
-    post_rps = _rate("post_per_sec", 3.0, max_v=3.0)
-    get_rps = _rate("get_per_sec", 20.0, max_v=20.0)
-    rl["post_per_sec"] = int(post_rps) if float(post_rps).is_integer() else float(post_rps)
-    rl["get_per_sec"] = int(get_rps) if float(get_rps).is_integer() else float(get_rps)
+    _normalize_rate_limit(p, 3.0, 20.0, post_max=3.0, get_max=20.0)
 
 
 def _is_hhmm(v: str) -> bool:

--- a/cw_platform/orchestrator/_unresolved.py
+++ b/cw_platform/orchestrator/_unresolved.py
@@ -62,6 +62,46 @@ def _pending_path(dst: str, feature: str) -> Path:
     return scoped_file(STATE_DIR, f"{dst_lower}_{feat_lower}.unresolved.pending.json")
 
 
+def _iter_unresolved_files(dst: str) -> Iterable[tuple[Path, bool]]:
+    """Yield ``(path, is_pending)`` for every unresolved-state file belonging to ``dst`` in STATE_DIR.
+
+    Legacy (unscoped) filenames are migrated to their scope-qualified equivalent
+    on the fly via ``scoped_file``. Callers are responsible for reading each path.
+    """
+    if not STATE_DIR.exists():
+        return
+
+    dst_lower = str(dst).strip().lower()
+    scope = scope_safe()
+
+    prefix = f"{dst_lower}_"
+    suffix = ".unresolved.json"
+    pending_suffix = ".unresolved.pending.json"
+    scoped1 = f".unresolved.{scope}.json"
+    scoped2 = f".{scope}.unresolved.json"
+    scopedp1 = f".unresolved.pending.{scope}.json"
+    scopedp2 = f".{scope}.unresolved.pending.json"
+    for p in STATE_DIR.iterdir():
+        if not p.is_file():
+            continue
+        name = p.name
+        if not name.startswith(prefix):
+            continue
+        is_blocking = (name.endswith(scoped1) or name.endswith(scoped2) or name.endswith(suffix))
+        is_pending = (name.endswith(scopedp1) or name.endswith(scopedp2) or name.endswith(pending_suffix))
+        if not (is_blocking or is_pending):
+            continue
+
+        # Migrate legacy (unscoped) files to scoped when needed.
+        rp = p
+        if (name.endswith(suffix) or name.endswith(pending_suffix)) and not (
+            name.endswith(scoped1) or name.endswith(scoped2) or name.endswith(scopedp1) or name.endswith(scopedp2)
+        ):
+            rp = scoped_file(STATE_DIR, name)
+
+        yield rp, is_pending
+
+
 # Blocking
 def load_unresolved_keys(
     dst: str,
@@ -74,7 +114,6 @@ def load_unresolved_keys(
         return keys
 
     dst_lower = str(dst).strip().lower()
-    scope = scope_safe()
 
     if feature and not cross_features:
         p = _blocking_path(dst_lower, feature)
@@ -82,45 +121,19 @@ def load_unresolved_keys(
             keys |= set(_read_json(p).keys())
         return keys
 
-    if not STATE_DIR.exists():
-        return keys
+    for rp, is_pending in _iter_unresolved_files(dst_lower):
+        data = _read_json(rp)
 
-    prefix = f"{dst_lower}_"
-    suffix = ".unresolved.json"
-    pending_suffix = ".unresolved.pending.json"
-    scoped1 = f".unresolved.{scope}.json"
-    scoped2 = f".{scope}.unresolved.json"
-    scopedp1 = f".unresolved.pending.{scope}.json"
-    scopedp2 = f".{scope}.unresolved.pending.json"
-    for p in STATE_DIR.iterdir():
-        if p.is_file():
-            name = p.name
-            if not name.startswith(prefix):
-                continue
-            is_blocking = (name.endswith(scoped1) or name.endswith(scoped2) or name.endswith(suffix))
-            is_pending = (name.endswith(scopedp1) or name.endswith(scopedp2) or name.endswith(pending_suffix))
-            if not (is_blocking or is_pending):
-                continue
-
-            # Migrate legacy (unscoped) files to scoped when needed.
-            rp = p
-            if (name.endswith(suffix) or name.endswith(pending_suffix)) and not (
-                name.endswith(scoped1) or name.endswith(scoped2) or name.endswith(scopedp1) or name.endswith(scopedp2)
-            ):
-                rp = scoped_file(STATE_DIR, name)
-
-            data = _read_json(rp)
-
-            if is_pending and isinstance(data, dict):
-                lst = data.get("keys")
-                if isinstance(lst, list):
-                    keys |= {str(x) for x in lst if x}
-                else:
-                    im = data.get("items")
-                    if isinstance(im, dict):
-                        keys |= {str(k) for k in im.keys()}
+        if is_pending and isinstance(data, dict):
+            lst = data.get("keys")
+            if isinstance(lst, list):
+                keys |= {str(x) for x in lst if x}
             else:
-                keys |= {str(k) for k in (data or {}).keys()}
+                im = data.get("items")
+                if isinstance(im, dict):
+                    keys |= {str(k) for k in im.keys()}
+        else:
+            keys |= {str(k) for k in (data or {}).keys()}
     return keys
 
 
@@ -135,7 +148,6 @@ def load_unresolved_map(
         return out
 
     dst_lower = str(dst).strip().lower()
-    scope = scope_safe()
 
     if feature and not cross_features:
         p = _blocking_path(dst_lower, feature)
@@ -145,46 +157,21 @@ def load_unresolved_map(
                 out[str(k)] = v if isinstance(v, dict) else {}
         return out
 
-    if not STATE_DIR.exists():
-        return out
-
-    prefix = f"{dst_lower}_"
-    suffix = ".unresolved.json"
-    pending_suffix = ".unresolved.pending.json"
-    scoped1 = f".unresolved.{scope}.json"
-    scoped2 = f".{scope}.unresolved.json"
-    scopedp1 = f".unresolved.pending.{scope}.json"
-    scopedp2 = f".{scope}.unresolved.pending.json"
-    for p in STATE_DIR.iterdir():
-        if p.is_file():
-            name = p.name
-            if not name.startswith(prefix):
-                continue
-            is_blocking = (name.endswith(scoped1) or name.endswith(scoped2) or name.endswith(suffix))
-            is_pending = (name.endswith(scopedp1) or name.endswith(scopedp2) or name.endswith(pending_suffix))
-            if not (is_blocking or is_pending):
-                continue
-
-            rp = p
-            if (name.endswith(suffix) or name.endswith(pending_suffix)) and not (
-                name.endswith(scoped1) or name.endswith(scoped2) or name.endswith(scopedp1) or name.endswith(scopedp2)
-            ):
-                rp = scoped_file(STATE_DIR, name)
-
-            data = _read_json(rp)
-            if is_pending and isinstance(data, dict):
-                raw_hints = data.get("hints")
-                hints = raw_hints if isinstance(raw_hints, dict) else {}
-                raw_keys = data.get("keys")
-                keys = raw_keys if isinstance(raw_keys, list) else []
-                for k in keys:
-                    if not k:
-                        continue
-                    v = (hints or {}).get(k) or {}
-                    out[str(k)] = v if isinstance(v, dict) else {}
-            else:
-                for k, v in (data or {}).items():
-                    out[str(k)] = v if isinstance(v, dict) else {}
+    for rp, is_pending in _iter_unresolved_files(dst_lower):
+        data = _read_json(rp)
+        if is_pending and isinstance(data, dict):
+            raw_hints = data.get("hints")
+            hints = raw_hints if isinstance(raw_hints, dict) else {}
+            raw_keys = data.get("keys")
+            keys = raw_keys if isinstance(raw_keys, list) else []
+            for k in keys:
+                if not k:
+                    continue
+                v = (hints or {}).get(k) or {}
+                out[str(k)] = v if isinstance(v, dict) else {}
+        else:
+            for k, v in (data or {}).items():
+                out[str(k)] = v if isinstance(v, dict) else {}
     return out
 
 

--- a/providers/scrobble/_sink_common.py
+++ b/providers/scrobble/_sink_common.py
@@ -79,6 +79,31 @@ def _cfg_delete_enabled(cfg: dict[str, Any], media_type: str) -> bool:
     return mt in allowed
 
 
+def _cfg_num(
+    cfg: dict[str, Any],
+    section: str,
+    key: str,
+    default: int | float,
+    fallback_section: str | None = None,
+) -> int | float:
+    """Read cfg["scrobble"][section][key], falling back to
+    cfg["scrobble"][fallback_section][key] when unset, else `default`.
+    Casts the result to the type of `default` (int or float); any lookup
+    or cast failure (missing/None/non-numeric) returns `default` as-is.
+    """
+    cast = type(default)
+    try:
+        s = cfg.get("scrobble") or {}
+        val = (s.get(section) or {}).get(key)
+        if val is None and fallback_section:
+            val = (s.get(fallback_section) or {}).get(key)
+        if val is None:
+            val = default
+        return cast(val)
+    except Exception:
+        return default
+
+
 def _extract_skeleton_from_body(b: dict[str, Any]) -> dict[str, Any]:
     out = dict(b)
     out.pop("progress", None)

--- a/providers/scrobble/mdblist/sink.py
+++ b/providers/scrobble/mdblist/sink.py
@@ -24,6 +24,7 @@ from providers.scrobble._sink_common import (
     _app_meta,
     _cfg,
     _cfg_delete_enabled,
+    _cfg_num,
     _clamp,
     _extract_skeleton_from_body,
     _is_debug,
@@ -90,59 +91,30 @@ def _max_retries(cfg: dict[str, Any]) -> int:
 
 
 def _stop_pause_threshold(cfg: dict[str, Any]) -> int:
-    try:
-        s = cfg.get("scrobble") or {}
-        return int((s.get("trakt") or {}).get("stop_pause_threshold", 85))
-    except Exception:
-        return 85
+    return _cfg_num(cfg, "trakt", "stop_pause_threshold", 85)
 
 
 def _force_stop_at(cfg: dict[str, Any]) -> int:
-    try:
-        s = cfg.get("scrobble") or {}
-        return int((s.get("trakt") or {}).get("force_stop_at", 95))
-    except Exception:
-        return 95
+    return _cfg_num(cfg, "trakt", "force_stop_at", 95)
 
 
 def _complete_at(cfg: dict[str, Any]) -> int:
-    try:
-        s = cfg.get("scrobble") or {}
-        return int((s.get("trakt") or {}).get("complete_at", 0))
-    except Exception:
-        return 0
+    return _cfg_num(cfg, "trakt", "complete_at", 0)
 
 
 def _regress_tolerance_percent(cfg: dict[str, Any]) -> int:
-    try:
-        s = cfg.get("scrobble") or {}
-        return int((s.get("trakt") or {}).get("regress_tolerance_percent", 5))
-    except Exception:
-        return 5
+    return _cfg_num(cfg, "trakt", "regress_tolerance_percent", 5)
 
 
 def _watch_pause_debounce(cfg: dict[str, Any]) -> int:
-    try:
-        return int(((cfg.get("scrobble") or {}).get("watch") or {}).get("pause_debounce_seconds", 5))
-    except Exception:
-        return 5
+    return _cfg_num(cfg, "watch", "pause_debounce_seconds", 5)
 
 
 def _watch_suppress_start_at(cfg: dict[str, Any]) -> int:
-    try:
-        return int(((cfg.get("scrobble") or {}).get("watch") or {}).get("suppress_start_at", 99))
-    except Exception:
-        return 99
+    return _cfg_num(cfg, "watch", "suppress_start_at", 99)
 
 def _progress_step(cfg: dict[str, Any]) -> int:
-    try:
-        s = cfg.get("scrobble") or {}
-        step = (s.get("mdblist") or {}).get("progress_step")
-        if step is None:
-            step = (s.get("trakt") or {}).get("progress_step", 5)
-        step_i = int(step)
-    except Exception:
-        step_i = 5
+    step_i = _cfg_num(cfg, "mdblist", "progress_step", 5, fallback_section="trakt")
     return max(1, min(25, step_i))
 
 

--- a/providers/scrobble/simkl/sink.py
+++ b/providers/scrobble/simkl/sink.py
@@ -24,6 +24,7 @@ from providers.scrobble._sink_common import (
     _ar_state_file,
     _cfg,
     _cfg_delete_enabled,
+    _cfg_num,
     _clamp,
     _extract_skeleton_from_body,
     _is_debug,
@@ -100,71 +101,30 @@ def _post(path: str, body: dict[str, Any], cfg: dict[str, Any]) -> requests.Resp
 
 
 def _stop_pause_threshold(cfg: dict[str, Any]) -> int:
-    try:
-        s = cfg.get("scrobble") or {}
-        src = (s.get("simkl") or {}).get("stop_pause_threshold")
-        if src is None:
-            src = (s.get("trakt") or {}).get("stop_pause_threshold", 85)
-        return int(src)
-    except Exception:
-        return 85
+    return _cfg_num(cfg, "simkl", "stop_pause_threshold", 85, fallback_section="trakt")
 
 
 def _force_stop_at(cfg: dict[str, Any]) -> int:
-    try:
-        s = cfg.get("scrobble") or {}
-        src = (s.get("simkl") or {}).get("force_stop_at")
-        if src is None:
-            src = (s.get("trakt") or {}).get("force_stop_at", 95)
-        return int(src)
-    except Exception:
-        return 95
+    return _cfg_num(cfg, "simkl", "force_stop_at", 95, fallback_section="trakt")
 
 
 def _complete_at(cfg: dict[str, Any]) -> int:
-    try:
-        s = cfg.get("scrobble") or {}
-        src = (s.get("simkl") or {}).get("complete_at")
-        if src is None:
-            src = (s.get("trakt") or {}).get("complete_at", 0)
-        return int(src)
-    except Exception:
-        return 0
+    return _cfg_num(cfg, "simkl", "complete_at", 0, fallback_section="trakt")
 
 
 def _regress_tolerance_percent(cfg: dict[str, Any]) -> int:
-    try:
-        s = cfg.get("scrobble") or {}
-        src = (s.get("simkl") or {}).get("regress_tolerance_percent")
-        if src is None:
-            src = (s.get("trakt") or {}).get("regress_tolerance_percent", 5)
-        return int(src)
-    except Exception:
-        return 5
+    return _cfg_num(cfg, "simkl", "regress_tolerance_percent", 5, fallback_section="trakt")
 
 
 def _watch_pause_debounce(cfg: dict[str, Any]) -> int:
-    try:
-        return int(((cfg.get("scrobble") or {}).get("watch") or {}).get("pause_debounce_seconds", 5))
-    except Exception:
-        return 5
+    return _cfg_num(cfg, "watch", "pause_debounce_seconds", 5)
 
 
 def _watch_suppress_start_at(cfg: dict[str, Any]) -> float:
-    try:
-        return float(((cfg.get("scrobble") or {}).get("watch") or {}).get("suppress_start_at", 99))
-    except Exception:
-        return 99.0
+    return _cfg_num(cfg, "watch", "suppress_start_at", 99.0)
 
 def _progress_step(cfg: dict[str, Any]) -> int:
-    try:
-        s = cfg.get("scrobble") or {}
-        step = (s.get("simkl") or {}).get("progress_step")
-        if step is None:
-            step = (s.get("trakt") or {}).get("progress_step", 5)
-        step_i = int(step)
-    except Exception:
-        step_i = 5
+    step_i = _cfg_num(cfg, "simkl", "progress_step", 5, fallback_section="trakt")
     return max(1, min(25, step_i))
 
 

--- a/providers/scrobble/trakt/sink.py
+++ b/providers/scrobble/trakt/sink.py
@@ -16,6 +16,7 @@ from providers.scrobble._sink_common import (
     _ar_state_file,
     _cfg,
     _cfg_delete_enabled,
+    _cfg_num,
     _extract_skeleton_from_body,
     _is_debug,
     _merged_provider_block,
@@ -209,45 +210,27 @@ def _clamp(p: Any) -> int:
 
 
 def _stop_pause_threshold(cfg: dict[str, Any]) -> int:
-    try:
-        return int(((cfg.get("scrobble") or {}).get("trakt") or {}).get("stop_pause_threshold", 85))
-    except Exception:
-        return 85
+    return _cfg_num(cfg, "trakt", "stop_pause_threshold", 85)
 
 
 def _force_stop_at(cfg: dict[str, Any]) -> int:
-    try:
-        return int(((cfg.get("scrobble") or {}).get("trakt") or {}).get("force_stop_at", 95))
-    except Exception:
-        return 95
+    return _cfg_num(cfg, "trakt", "force_stop_at", 95)
 
 
 def _complete_at(cfg: dict[str, Any]) -> int:
-    try:
-        return int(((cfg.get("scrobble") or {}).get("trakt") or {}).get("complete_at", 0))
-    except Exception:
-        return 0
+    return _cfg_num(cfg, "trakt", "complete_at", 0)
 
 
 def _regress_tol(cfg: dict[str, Any]) -> int:
-    try:
-        return int(((cfg.get("scrobble") or {}).get("trakt") or {}).get("regress_tolerance_percent", 5))
-    except Exception:
-        return 5
+    return _cfg_num(cfg, "trakt", "regress_tolerance_percent", 5)
 
 
 def _watch_pause_debounce(cfg: dict[str, Any]) -> int:
-    try:
-        return int(((cfg.get("scrobble") or {}).get("watch") or {}).get("pause_debounce_seconds", 5))
-    except Exception:
-        return 5
+    return _cfg_num(cfg, "watch", "pause_debounce_seconds", 5)
 
 
 def _watch_suppress_start_at(cfg: dict[str, Any]) -> float:
-    try:
-        return float(((cfg.get("scrobble") or {}).get("watch") or {}).get("suppress_start_at", 99))
-    except Exception:
-        return 99.0
+    return _cfg_num(cfg, "watch", "suppress_start_at", 99.0)
 
 def _trakt_progress_step(cfg: dict[str, Any]) -> int:
     try:

--- a/services/scheduling.py
+++ b/services/scheduling.py
@@ -961,20 +961,14 @@ class SyncScheduler:
                 err = "event_rule_failed"
                 ok = False
 
-            with self._lock:
-                self._status["last_run_ok"] = ok
-                self._status["last_run_at"] = _now_ts()
-                self._status["last_error"] = err if err else ("" if ok else "event rule failed")
-                self._status["last_job_id"] = ""
-                self._status["last_pair_id"] = pair_id
-                self._status["last_capture_job_id"] = ""
-                self._status["last_capture_provider"] = ""
-                self._status["last_capture_feature"] = ""
-                self._status["last_backup_job_id"] = ""
-                self._status["last_backup_scope"] = ""
-                self._status["last_rule_id"] = str(rule.get("id") or "")
-                self._status["last_event_source"] = str(event.get("source") or "")
-                self._status["last_event_name"] = str(event.get("event") or "")
+            self._set_last_run_status(
+                ok,
+                err if err else ("" if ok else "event rule failed"),
+                last_pair_id=pair_id,
+                last_rule_id=str(rule.get("id") or ""),
+                last_event_source=str(event.get("source") or ""),
+                last_event_name=str(event.get("event") or ""),
+            )
 
             if not ok:
                 skipped.append({"rule_id": str(rule.get("id") or ""), "reason": "run_failed"})
@@ -1123,6 +1117,46 @@ class SyncScheduler:
         due.sort(key=lambda x: (x[0], str(x[1].get("id") or "")))
         return due
 
+    def _wait_until_sync_free(self, busy_msg: str) -> bool:
+        """Poll every 2s until sync is free or stop is requested.
+
+        Returns True if a poke fired mid-wait (config changed), meaning the
+        caller should return early so due jobs get re-evaluated; returns
+        False once sync is free (or stop was requested).
+        """
+        waited = 0
+        while self.is_sync_running_fn() and not self._stop.is_set():
+            if waited == 0:
+                self._log(busy_msg, level="INFO")
+            waited += 1
+            self._sleep_or_poke(2.0)
+            if self._poke.is_set():
+                self._poke.clear()
+                return True
+        return False
+
+    def _set_last_run_status(self, ok: bool, error: str, **overrides: Any) -> None:
+        """Reset the last-run status fields under the scheduler lock.
+
+        Unset last_* keys default to "" per existing convention; pass
+        overrides (e.g. last_job_id=..., last_pair_id=...) to set the
+        identifiers relevant to this run.
+        """
+        with self._lock:
+            self._status["last_run_ok"] = ok
+            self._status["last_run_at"] = _now_ts()
+            self._status["last_error"] = error
+            self._status["last_job_id"] = overrides.get("last_job_id", "")
+            self._status["last_pair_id"] = overrides.get("last_pair_id", "")
+            self._status["last_capture_job_id"] = overrides.get("last_capture_job_id", "")
+            self._status["last_capture_provider"] = overrides.get("last_capture_provider", "")
+            self._status["last_capture_feature"] = overrides.get("last_capture_feature", "")
+            self._status["last_backup_job_id"] = overrides.get("last_backup_job_id", "")
+            self._status["last_backup_scope"] = overrides.get("last_backup_scope", "")
+            self._status["last_rule_id"] = overrides.get("last_rule_id", "")
+            self._status["last_event_source"] = overrides.get("last_event_source", "")
+            self._status["last_event_name"] = overrides.get("last_event_name", "")
+
     def _adv_run_due(self, sch: dict[str, Any], tz: Any | None) -> bool:
         due = self._adv_due_jobs(sch, tz)
         due_capture = self._adv_due_capture_jobs(sch, tz)
@@ -1146,16 +1180,8 @@ class SyncScheduler:
                 continue
 
             # Wait until sync is free
-            waited = 0
-            while self.is_sync_running_fn() and not self._stop.is_set():
-                if waited == 0:
-                    self._log("advanced: sync is busy; waiting to run due job(s)", level="INFO")
-                waited += 1
-                self._sleep_or_poke(2.0)
-                if self._poke.is_set():
-                    self._poke.clear()
-                    # re-check due after config change
-                    return True
+            if self._wait_until_sync_free("advanced: sync is busy; waiting to run due job(s)"):
+                return True
 
             payload = {
                 "source": "scheduler",
@@ -1172,20 +1198,12 @@ class SyncScheduler:
             else:
                 self._log(f"advanced: job {j['id']} ok", level="INFO")
 
-            with self._lock:
-                self._status["last_run_ok"] = ok
-                self._status["last_run_at"] = _now_ts()
-                self._status["last_error"] = "" if ok else "advanced job failed"
-                self._status["last_job_id"] = j["id"]
-                self._status["last_pair_id"] = j["pair_id"] or ""
-                self._status["last_capture_job_id"] = ""
-                self._status["last_capture_provider"] = ""
-                self._status["last_capture_feature"] = ""
-                self._status["last_backup_job_id"] = ""
-                self._status["last_backup_scope"] = ""
-                self._status["last_rule_id"] = ""
-                self._status["last_event_source"] = ""
-                self._status["last_event_name"] = ""
+            self._set_last_run_status(
+                ok,
+                "" if ok else "advanced job failed",
+                last_job_id=j["id"],
+                last_pair_id=j["pair_id"] or "",
+            )
 
             self._adv_last_key[j["id"]] = f"{today}@{j.get('at')}"
             executed.add(j["id"])
@@ -1194,15 +1212,8 @@ class SyncScheduler:
             if self._stop.is_set():
                 break
 
-            waited = 0
-            while self.is_sync_running_fn() and not self._stop.is_set():
-                if waited == 0:
-                    self._log("advanced capture: sync is busy; waiting to run due capture job(s)", level="INFO")
-                waited += 1
-                self._sleep_or_poke(2.0)
-                if self._poke.is_set():
-                    self._poke.clear()
-                    return True
+            if self._wait_until_sync_free("advanced capture: sync is busy; waiting to run due capture job(s)"):
+                return True
 
             payload = {
                 "source": "scheduler",
@@ -1230,35 +1241,21 @@ class SyncScheduler:
             else:
                 self._log(f"advanced capture: job {j['id']} ok", level="INFO")
 
-            with self._lock:
-                self._status["last_run_ok"] = ok
-                self._status["last_run_at"] = _now_ts()
-                self._status["last_error"] = "" if ok else "advanced capture job failed"
-                self._status["last_job_id"] = ""
-                self._status["last_pair_id"] = ""
-                self._status["last_capture_job_id"] = j["id"]
-                self._status["last_capture_provider"] = j["provider"] or ""
-                self._status["last_capture_feature"] = j["feature"] or ""
-                self._status["last_backup_job_id"] = ""
-                self._status["last_backup_scope"] = ""
-                self._status["last_rule_id"] = ""
-                self._status["last_event_source"] = ""
-                self._status["last_event_name"] = ""
+            self._set_last_run_status(
+                ok,
+                "" if ok else "advanced capture job failed",
+                last_capture_job_id=j["id"],
+                last_capture_provider=j["provider"] or "",
+                last_capture_feature=j["feature"] or "",
+            )
 
             self._adv_last_key[j["id"]] = f"{today}@{j.get('at')}"
         for _, j in due_backup:
             if self._stop.is_set():
                 break
 
-            waited = 0
-            while self.is_sync_running_fn() and not self._stop.is_set():
-                if waited == 0:
-                    self._log("advanced backup: sync is busy; waiting to run due backup job(s)", level="INFO")
-                waited += 1
-                self._sleep_or_poke(2.0)
-                if self._poke.is_set():
-                    self._poke.clear()
-                    return True
+            if self._wait_until_sync_free("advanced backup: sync is busy; waiting to run due backup job(s)"):
+                return True
 
             payload = {
                 "source": "scheduler",
@@ -1287,20 +1284,12 @@ class SyncScheduler:
             else:
                 self._log(f"advanced backup: job {j['id']} ok", level="INFO")
 
-            with self._lock:
-                self._status["last_run_ok"] = ok
-                self._status["last_run_at"] = _now_ts()
-                self._status["last_error"] = "" if ok else "advanced backup job failed"
-                self._status["last_job_id"] = ""
-                self._status["last_pair_id"] = ""
-                self._status["last_capture_job_id"] = ""
-                self._status["last_capture_provider"] = ""
-                self._status["last_capture_feature"] = ""
-                self._status["last_backup_job_id"] = j["id"]
-                self._status["last_backup_scope"] = j["scope"] or ""
-                self._status["last_rule_id"] = ""
-                self._status["last_event_source"] = ""
-                self._status["last_event_name"] = ""
+            self._set_last_run_status(
+                ok,
+                "" if ok else "advanced backup job failed",
+                last_backup_job_id=j["id"],
+                last_backup_scope=j["scope"] or "",
+            )
 
             self._adv_last_key[j["id"]] = f"{today}@{j.get('at')}"
         return ok_all
@@ -1309,20 +1298,7 @@ class SyncScheduler:
         payload = {"source": "scheduler", "scheduler_mode": "standard"}
         self._log("standard: triggering sync run", level="INFO")
         ok = self._run_sync(payload)
-        with self._lock:
-            self._status["last_run_ok"] = ok
-            self._status["last_run_at"] = _now_ts()
-            self._status["last_error"] = "" if ok else "standard run failed"
-            self._status["last_job_id"] = ""
-            self._status["last_pair_id"] = ""
-            self._status["last_capture_job_id"] = ""
-            self._status["last_capture_provider"] = ""
-            self._status["last_capture_feature"] = ""
-            self._status["last_backup_job_id"] = ""
-            self._status["last_backup_scope"] = ""
-            self._status["last_rule_id"] = ""
-            self._status["last_event_source"] = ""
-            self._status["last_event_name"] = ""
+        self._set_last_run_status(ok, "" if ok else "standard run failed")
         self._log("standard: run ok" if ok else "standard: run failed", level="INFO" if ok else "ERROR")
         return ok
 

--- a/services/snapshots.py
+++ b/services/snapshots.py
@@ -1307,16 +1307,16 @@ def _with_feature_tag(item: Any, feature: str) -> Any:
     return {"feature": feature, **dict(item)}
 
 
+def _load_and_classify(a_path: str, b_path: str) -> dict[str, Any]:
+    """Load two snapshots, validate they're comparable, and classify items.
 
-
-def diff_snapshots(
-    a_path: str,
-    b_path: str,
-    *,
-    limit: int = 200,
-    max_depth: int = 4,
-    max_changes: int = 25,
-) -> dict[str, Any]:
+    Shared by `diff_snapshots` and `diff_snapshots_extended`. Always
+    validates provider/instance match and detects bundle captures. For
+    bundle captures, returns early (only `a`/`b`/`bundle_a`/`bundle_b` are
+    populated) since each caller aggregates per-feature bundles differently.
+    For single-feature captures, also canonicalizes items and classifies
+    them into added/removed/updated/unchanged keys.
+    """
     a = read_snapshot(a_path)
     b = read_snapshot(b_path)
 
@@ -1334,6 +1334,136 @@ def diff_snapshots(
 
     bundle_a = kind_a == SNAPSHOT_BUNDLE_KIND or feat_a == "all"
     bundle_b = kind_b == SNAPSHOT_BUNDLE_KIND or feat_b == "all"
+
+    out: dict[str, Any] = {"a": a, "b": b, "bundle_a": bundle_a, "bundle_b": bundle_b}
+    if bundle_a or bundle_b:
+        return out
+
+    items_a_raw = a.get("items") or {}
+    items_b_raw = b.get("items") or {}
+    if not isinstance(items_a_raw, Mapping) or not isinstance(items_b_raw, Mapping):
+        raise ValueError("Invalid capture contents")
+
+    if feat_a != feat_b:
+        raise ValueError("Compare Captures only supports the same feature.")
+
+    feat = _norm_feature(feat_a)
+    items_a_raw = _canonicalize_index(prov_a, feat, items_a_raw)
+    items_b_raw = _canonicalize_index(prov_a, feat, items_b_raw)
+
+    history_multi = False
+    if feat_a == "history":
+        items_a = _history_items_by_base_key(items_a_raw)
+        items_b = _history_items_by_base_key(items_b_raw)
+        history_multi = True
+    else:
+        items_a = dict(items_a_raw)
+        items_b = dict(items_b_raw)
+
+    keys_a = set(str(k) for k in items_a.keys())
+    keys_b = set(str(k) for k in items_b.keys())
+    added_keys = sorted(keys_b - keys_a)
+    removed_keys = sorted(keys_a - keys_b)
+    common = sorted(keys_a & keys_b)
+
+    updated_keys: list[str] = []
+    unchanged_keys: list[str] = []
+    for k in common:
+        va = items_a.get(k)
+        vb = items_b.get(k)
+        if history_multi:
+            oa = va if isinstance(va, Mapping) else {}
+            ob = vb if isinstance(vb, Mapping) else {}
+            a_tmp = oa.get("watched_ats")
+            b_tmp = ob.get("watched_ats")
+            a_dates = a_tmp if isinstance(a_tmp, list) else []
+            b_dates = b_tmp if isinstance(b_tmp, list) else []
+            a_set = _minute_set([str(x) for x in a_dates])
+            b_set = _minute_set([str(x) for x in b_dates])
+            if a_set != b_set:
+                updated_keys.append(k)
+                continue
+            oa2 = dict(oa)
+            ob2 = dict(ob)
+            oa2.pop("watched_ats", None)
+            ob2.pop("watched_ats", None)
+            if _cmp_record_minute(oa2) != _cmp_record_minute(ob2):
+                updated_keys.append(k)
+            else:
+                unchanged_keys.append(k)
+            continue
+        if va != vb:
+            updated_keys.append(k)
+        else:
+            unchanged_keys.append(k)
+
+    out.update(
+        {
+            "feat": feat,
+            "items_a_raw": items_a_raw,
+            "items_b_raw": items_b_raw,
+            "items_a": items_a,
+            "items_b": items_b,
+            "history_multi": history_multi,
+            "keys_a": keys_a,
+            "keys_b": keys_b,
+            "added_keys": added_keys,
+            "removed_keys": removed_keys,
+            "updated_keys": updated_keys,
+            "unchanged_keys": unchanged_keys,
+            "common": common,
+        }
+    )
+    return out
+
+
+def _history_watched_changes(va: Any, vb: Any, *, max_depth: int, max_changes: int) -> list[dict[str, Any]]:
+    """Build the `changes` list for a history_multi 'updated' row.
+
+    Reports watched_ats differences at minute precision as add/remove
+    markers, then diffs the remaining fields (with watched_ats stripped)
+    via `_diff_any` if they differ.
+    """
+    oa = va if isinstance(va, Mapping) else {}
+    ob = vb if isinstance(vb, Mapping) else {}
+    a_tmp = oa.get("watched_ats")
+    b_tmp = ob.get("watched_ats")
+    a_dates = a_tmp if isinstance(a_tmp, list) else []
+    b_dates = b_tmp if isinstance(b_tmp, list) else []
+    a_set = _minute_set([str(x) for x in a_dates])
+    b_set = _minute_set([str(x) for x in b_dates])
+    added_dates = sorted(b_set - a_set)
+    removed_dates = sorted(a_set - b_set)
+
+    changes: list[dict[str, Any]] = []
+    if added_dates:
+        changes.append({"path": "watched_ats.added", "old": [], "new": added_dates})
+    if removed_dates:
+        changes.append({"path": "watched_ats.removed", "old": removed_dates, "new": []})
+
+    oa2 = dict(oa)
+    ob2 = dict(ob)
+    oa2.pop("watched_ats", None)
+    ob2.pop("watched_ats", None)
+    if _cmp_record_minute(oa2) != _cmp_record_minute(ob2):
+        _diff_any(oa2, ob2, path="", out=changes, max_depth=max_depth, max_changes=max_changes)
+    return changes
+
+
+
+def diff_snapshots(
+    a_path: str,
+    b_path: str,
+    *,
+    limit: int = 200,
+    max_depth: int = 4,
+    max_changes: int = 25,
+) -> dict[str, Any]:
+    loaded = _load_and_classify(a_path, b_path)
+    a = loaded["a"]
+    b = loaded["b"]
+    bundle_a = loaded["bundle_a"]
+    bundle_b = loaded["bundle_b"]
     if bundle_a or bundle_b:
         if bundle_a and bundle_b:
             a_children, b_children, features, _ = _bundle_compare_setup(a, b, "all")
@@ -1384,60 +1514,17 @@ def diff_snapshots(
             }
         raise ValueError("Compare Captures only supports two full captures or two matching feature captures.")
 
-    items_a_raw = a.get("items") or {}
-    items_b_raw = b.get("items") or {}
-    if not isinstance(items_a_raw, Mapping) or not isinstance(items_b_raw, Mapping):
-        raise ValueError("Invalid capture contents")
-
-    if feat_a != feat_b:
-        raise ValueError("Compare Captures only supports the same feature.")
-
-    items_a_raw = _canonicalize_index(prov_a, _norm_feature(feat_a), items_a_raw)
-    items_b_raw = _canonicalize_index(prov_a, _norm_feature(feat_a), items_b_raw)
-
-    history_multi = False
-    if feat_a == "history":
-        items_a = _history_items_by_base_key(items_a_raw)
-        items_b = _history_items_by_base_key(items_b_raw)
-        history_multi = True
-    else:
-        items_a = dict(items_a_raw)
-        items_b = dict(items_b_raw)
-
-    keys_a = set(str(k) for k in items_a.keys())
-    keys_b = set(str(k) for k in items_b.keys())
-
-    added_keys = sorted(keys_b - keys_a)
-    removed_keys = sorted(keys_a - keys_b)
-
-    common = sorted(keys_a & keys_b)
-    updated_keys: list[str] = []
-    for k in common:
-        va = items_a.get(k)
-        vb = items_b.get(k)
-        if history_multi:
-            oa = va if isinstance(va, Mapping) else {}
-            ob = vb if isinstance(vb, Mapping) else {}
-            a_tmp = oa.get("watched_ats")
-            b_tmp = ob.get("watched_ats")
-            a_dates = a_tmp if isinstance(a_tmp, list) else []
-            b_dates = b_tmp if isinstance(b_tmp, list) else []
-            a_set = set(_iso_minute(x) or str(x) for x in a_dates)
-            b_set = set(_iso_minute(x) or str(x) for x in b_dates)
-            if a_set != b_set:
-                updated_keys.append(k)
-                continue
-            oa2 = dict(oa)
-            ob2 = dict(ob)
-            oa2.pop("watched_ats", None)
-            ob2.pop("watched_ats", None)
-            if _cmp_record_minute(oa2) != _cmp_record_minute(ob2):
-                updated_keys.append(k)
-            continue
-        if va != vb:
-            updated_keys.append(k)
-
-    unchanged = len(common) - len(updated_keys)
+    items_a_raw = loaded["items_a_raw"]
+    items_b_raw = loaded["items_b_raw"]
+    items_a = loaded["items_a"]
+    items_b = loaded["items_b"]
+    history_multi = loaded["history_multi"]
+    keys_a = loaded["keys_a"]
+    keys_b = loaded["keys_b"]
+    added_keys = loaded["added_keys"]
+    removed_keys = loaded["removed_keys"]
+    updated_keys = loaded["updated_keys"]
+    unchanged = len(loaded["common"]) - len(updated_keys)
 
     lim = max(1, min(int(limit or 200), 2000))
 
@@ -1451,28 +1538,7 @@ def diff_snapshots(
         changes: list[dict[str, Any]] = []
 
         if history_multi:
-            oa = va if isinstance(va, Mapping) else {}
-            ob = vb if isinstance(vb, Mapping) else {}
-            a_tmp = oa.get("watched_ats")
-            b_tmp = ob.get("watched_ats")
-            a_dates = a_tmp if isinstance(a_tmp, list) else []
-            b_dates = b_tmp if isinstance(b_tmp, list) else []
-            a_set = _minute_set([str(x) for x in a_dates])
-            b_set = _minute_set([str(x) for x in b_dates])
-            added_dates = sorted(b_set - a_set)
-            removed_dates = sorted(a_set - b_set)
-
-            if added_dates:
-                changes.append({"path": "watched_ats.added", "old": [], "new": added_dates})
-            if removed_dates:
-                changes.append({"path": "watched_ats.removed", "old": removed_dates, "new": []})
-
-            oa2 = dict(oa)
-            ob2 = dict(ob)
-            oa2.pop("watched_ats", None)
-            ob2.pop("watched_ats", None)
-            if _cmp_record_minute(oa2) != _cmp_record_minute(ob2):
-                _diff_any(oa2, ob2, path="", out=changes, max_depth=max_depth, max_changes=max_changes)
+            changes = _history_watched_changes(va, vb, max_depth=max_depth, max_changes=max_changes)
         else:
             _diff_any(va, vb, path="", out=changes, max_depth=max_depth, max_changes=max_changes)
 
@@ -1522,23 +1588,11 @@ def diff_snapshots_extended(
     max_changes: int = 250,
 ) -> dict[str, Any]:
 
-    a = read_snapshot(a_path)
-    b = read_snapshot(b_path)
-
-    kind_a = str(a.get("kind") or "").strip().lower()
-    kind_b = str(b.get("kind") or "").strip().lower()
-    feat_a = str(a.get("feature") or "").strip().lower()
-    feat_b = str(b.get("feature") or "").strip().lower()
-
-    prov_a = str(a.get("provider") or "").strip().upper()
-    prov_b = str(b.get("provider") or "").strip().upper()
-    inst_a = str(a.get("instance") or a.get("instance_id") or a.get("profile") or "default").strip().lower()
-    inst_b = str(b.get("instance") or b.get("instance_id") or b.get("profile") or "default").strip().lower()
-    if prov_a != prov_b or inst_a != inst_b:
-        raise ValueError("Compare Captures only supports the same provider and instance.")
-
-    bundle_a = kind_a == SNAPSHOT_BUNDLE_KIND or feat_a == "all"
-    bundle_b = kind_b == SNAPSHOT_BUNDLE_KIND or feat_b == "all"
+    loaded = _load_and_classify(a_path, b_path)
+    a = loaded["a"]
+    b = loaded["b"]
+    bundle_a = loaded["bundle_a"]
+    bundle_b = loaded["bundle_b"]
     selected_feature = str(feature or "").strip().lower()
     if bundle_a or bundle_b:
         if not (bundle_a and bundle_b):
@@ -1570,64 +1624,18 @@ def diff_snapshots_extended(
         child_res["selected_feature"] = selected_feature
         return child_res
 
-    items_a_raw = a.get("items") or {}
-    items_b_raw = b.get("items") or {}
-    if not isinstance(items_a_raw, Mapping) or not isinstance(items_b_raw, Mapping):
-        raise ValueError("Invalid capture contents")
-
-    if feat_a != feat_b:
-        raise ValueError("Compare Captures only supports the same feature.")
-
-    feat = _norm_feature(feat_a)
-    items_a_raw = _canonicalize_index(prov_a, feat, items_a_raw)
-    items_b_raw = _canonicalize_index(prov_a, feat, items_b_raw)
-
-    history_multi = False
-    if feat_a == "history":
-        items_a = _history_items_by_base_key(items_a_raw)
-        items_b = _history_items_by_base_key(items_b_raw)
-        history_multi = True
-    else:
-        items_a = dict(items_a_raw)
-        items_b = dict(items_b_raw)
-
-    keys_a = set(str(k) for k in items_a.keys())
-    keys_b = set(str(k) for k in items_b.keys())
-    common = sorted(keys_a & keys_b)
-
-    added_keys = sorted(keys_b - keys_a)
-    removed_keys = sorted(keys_a - keys_b)
-
-    updated_keys: list[str] = []
-    unchanged_keys: list[str] = []
-    for k in common:
-        va = items_a.get(k)
-        vb = items_b.get(k)
-        if history_multi:
-            oa = va if isinstance(va, Mapping) else {}
-            ob = vb if isinstance(vb, Mapping) else {}
-            a_tmp = oa.get("watched_ats")
-            b_tmp = ob.get("watched_ats")
-            a_dates = a_tmp if isinstance(a_tmp, list) else []
-            b_dates = b_tmp if isinstance(b_tmp, list) else []
-            a_set = _minute_set([str(x) for x in a_dates])
-            b_set = _minute_set([str(x) for x in b_dates])
-            if a_set != b_set:
-                updated_keys.append(k)
-                continue
-            oa2 = dict(oa)
-            ob2 = dict(ob)
-            oa2.pop("watched_ats", None)
-            ob2.pop("watched_ats", None)
-            if _cmp_record_minute(oa2) != _cmp_record_minute(ob2):
-                updated_keys.append(k)
-            else:
-                unchanged_keys.append(k)
-            continue
-        if va != vb:
-            updated_keys.append(k)
-        else:
-            unchanged_keys.append(k)
+    feat = loaded["feat"]
+    items_a_raw = loaded["items_a_raw"]
+    items_b_raw = loaded["items_b_raw"]
+    items_a = loaded["items_a"]
+    items_b = loaded["items_b"]
+    history_multi = loaded["history_multi"]
+    keys_a = loaded["keys_a"]
+    keys_b = loaded["keys_b"]
+    added_keys = loaded["added_keys"]
+    removed_keys = loaded["removed_keys"]
+    updated_keys = loaded["updated_keys"]
+    unchanged_keys = loaded["unchanged_keys"]
 
     # Filter helpers
     want = str(kind or "all").strip().lower()
@@ -1678,26 +1686,7 @@ def diff_snapshots_extended(
             row["new"] = vb
             changes: list[dict[str, Any]] = []
             if history_multi:
-                oa = va if isinstance(va, Mapping) else {}
-                ob = vb if isinstance(vb, Mapping) else {}
-                a_tmp = oa.get("watched_ats")
-                b_tmp = ob.get("watched_ats")
-                a_dates = a_tmp if isinstance(a_tmp, list) else []
-                b_dates = b_tmp if isinstance(b_tmp, list) else []
-                a_set = _minute_set([str(x) for x in a_dates])
-                b_set = _minute_set([str(x) for x in b_dates])
-                add_dates = sorted(b_set - a_set)
-                del_dates = sorted(a_set - b_set)
-                if add_dates:
-                    changes.append({"path": "watched_ats.added", "old": [], "new": add_dates})
-                if del_dates:
-                    changes.append({"path": "watched_ats.removed", "old": del_dates, "new": []})
-                oa2 = dict(oa)
-                ob2 = dict(ob)
-                oa2.pop("watched_ats", None)
-                ob2.pop("watched_ats", None)
-                if _cmp_record_minute(oa2) != _cmp_record_minute(ob2):
-                    _diff_any(oa2, ob2, path="", out=changes, max_depth=max_depth, max_changes=max_changes)
+                changes = _history_watched_changes(va, vb, max_depth=max_depth, max_changes=max_changes)
             else:
                 _diff_any(va, vb, path="", out=changes, max_depth=max_depth, max_changes=max_changes)
             row["changes"] = changes

--- a/services/statistics.py
+++ b/services/statistics.py
@@ -86,6 +86,118 @@ def _write_json_atomic(p: Path, data: dict[str, Any]) -> None:
                 pass
 
 
+def _norm_title(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s or "")
+    s = "".join(ch for ch in s if not unicodedata.combining(ch)).casefold()
+    s = re.sub(r"\([^)]*\)|\[[^\]]*\]", " ", s)
+    s = s.replace("&", " and ")
+    s = re.sub(r"[^a-z0-9]+", " ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    toks = s.split()
+    if toks and toks[0] in {"the", "a", "an"}:
+        s = " ".join(toks[1:])
+    return s
+
+
+def _title_key(m: dict[str, Any]) -> str:
+    return _norm_title((m.get("title") or "").strip())
+
+
+def _similar(a: str, b: str) -> bool:
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    ta, tb = set(a.split()), set(b.split())
+    if ta and (len(ta & tb) / len(ta | tb)) >= 0.85:
+        return True
+    return difflib.SequenceMatcher(None, a, b).ratio() >= 0.92
+
+
+def _titles_match_loose(rm: dict[str, Any], am: dict[str, Any]) -> bool:
+    ra, aa = _title_key(rm), _title_key(am)
+    if not ra or not aa:
+        return False
+    ry, ay = Stats._year_of(rm), Stats._year_of(am)
+    if isinstance(ry, int) and isinstance(ay, int) and ry != ay:
+        return False
+    return ra == aa or _similar(ra, aa)
+
+
+def _provset(m: dict[str, Any]) -> set[str]:
+    provs = {str(p).lower() for p in (m.get("providers") or [])}
+    if not provs:
+        s = str(m.get("src") or "").lower()
+        if s and s != "both":
+            provs = {s}
+    return provs
+
+
+_IDCORE = re.compile(
+    r"^(?P<p>[a-z0-9]+):(?:(?:movie|tv|show):)?(?P<i>[^:]+)$",
+    re.I,
+)
+
+
+def _idcore(k: str) -> tuple[str | None, str | None]:
+    m = _IDCORE.match(str(k) or "")
+    return (m.group("p"), m.group("i")) if m else (None, None)
+
+
+def _mk_event(action: str, feat: str, key: str, m: dict[str, Any], now_epoch: int) -> dict[str, Any]:
+    return {
+        "ts": now_epoch,
+        "action": action,
+        "feature": feat,
+        "key": key,
+        "source": m.get("src", ""),
+        "title": m.get("title", ""),
+        "type": m.get("type", ""),
+    }
+
+
+def _emit_lane_events(
+    ev: list[dict[str, Any]],
+    feature: str,
+    prev_map: dict[str, Any],
+    cur_map: dict[str, Any],
+    now_epoch: int,
+) -> tuple[list[str], list[str]]:
+    """Diff a feature's previous vs. current key->item maps and append events onto `ev`.
+
+    Pairs likely renames (matching/similar title with an overlapping
+    provider, or a matching id-core) into a single "update" event instead
+    of a separate add+remove, then emits "add"/"remove" events for
+    whatever is left unpaired. Returns the final (adds, removes) key
+    lists after rename pairing.
+    """
+    pk, ck = set(prev_map), set(cur_map)
+    adds, rems = sorted(ck - pk), sorted(pk - ck)
+
+    for rk in list(rems):
+        rm = prev_map.get(rk) or {}
+        rp = _provset(rm)
+        rp_name, rp_id = _idcore(rk)
+        for ak in list(adds):
+            am = cur_map.get(ak) or {}
+            ap = _provset(am)
+            ap_name, ap_id = _idcore(ak)
+            same_title = _titles_match_loose(rm, am)
+            same_idcore = rp_name == ap_name and rp_id and ap_id and rp_id == ap_id
+            if (same_title or same_idcore) and (rp & ap or same_idcore):
+                rems.remove(rk)
+                adds.remove(ak)
+                ev.append(_mk_event("update", feature, ak, am, now_epoch))
+                break
+
+    for k in adds:
+        ev.append(_mk_event("add", feature, k, cur_map.get(k) or {}, now_epoch))
+    for k in rems:
+        ev.append(_mk_event("remove", feature, k, prev_map.get(k) or {}, now_epoch))
+
+    return adds, rems
+
+
 class Stats:
     def __init__(self, path: Path | None = None) -> None:
         self.path = Path(path) if path else STATS_PATH
@@ -533,114 +645,7 @@ class Stats:
             prev_wl = {k: dict(v) for k, v in (self.data.get("current") or {}).items()}
             cur_wl = self._build_union_map(state, "watchlist")
 
-            def _norm_title(s: str) -> str:
-                s = unicodedata.normalize("NFKD", s or "")
-                s = "".join(ch for ch in s if not unicodedata.combining(ch)).casefold()
-                s = re.sub(r"\([^)]*\)|\[[^\]]*\]", " ", s)
-                s = s.replace("&", " and ")
-                s = re.sub(r"[^a-z0-9]+", " ", s)
-                s = re.sub(r"\s+", " ", s).strip()
-                toks = s.split()
-                if toks and toks[0] in {"the", "a", "an"}:
-                    s = " ".join(toks[1:])
-                return s
-
-            def _title_key(m: dict[str, Any]) -> str:
-                return _norm_title((m.get("title") or "").strip())
-
-            def _similar(a: str, b: str) -> bool:
-                if not a or not b:
-                    return False
-                if a == b:
-                    return True
-                ta, tb = set(a.split()), set(b.split())
-                if ta and (len(ta & tb) / len(ta | tb)) >= 0.85:
-                    return True
-                return difflib.SequenceMatcher(None, a, b).ratio() >= 0.92
-
-            def _titles_match_loose(rm: dict[str, Any], am: dict[str, Any]) -> bool:
-                ra, aa = _title_key(rm), _title_key(am)
-                if not ra or not aa:
-                    return False
-                ry, ay = self._year_of(rm), self._year_of(am)
-                if isinstance(ry, int) and isinstance(ay, int) and ry != ay:
-                    return False
-                return ra == aa or _similar(ra, aa)
-
-            def _provset(m: dict[str, Any]) -> set[str]:
-                provs = {str(p).lower() for p in (m.get("providers") or [])}
-                if not provs:
-                    s = str(m.get("src") or "").lower()
-                    if s and s != "both":
-                        provs = {s}
-                return provs
-
-            _IDCORE = re.compile(
-                r"^(?P<p>[a-z0-9]+):(?:(?:movie|tv|show):)?(?P<i>[^:]+)$",
-                re.I,
-            )
-
-            def _idcore(k: str) -> tuple[str | None, str | None]:
-                m = _IDCORE.match(str(k) or "")
-                return (m.group("p"), m.group("i")) if m else (None, None)
-
-            pk, ck = set(prev_wl), set(cur_wl)
-            added_keys, removed_keys = sorted(ck - pk), sorted(pk - ck)
-
-            for rk in list(removed_keys):
-                rm = prev_wl.get(rk) or {}
-                rp = _provset(rm)
-                rp_name, rp_id = _idcore(rk)
-                for ak in list(added_keys):
-                    am = cur_wl.get(ak) or {}
-                    ap = _provset(am)
-                    ap_name, ap_id = _idcore(ak)
-                    same_title = _titles_match_loose(rm, am)
-                    same_idcore = (
-                        rp_name == ap_name and rp_id and ap_id and rp_id == ap_id
-                    )
-                    if (same_title or same_idcore) and (rp & ap or same_idcore):
-                        removed_keys.remove(rk)
-                        added_keys.remove(ak)
-                        ev.append(
-                            {
-                                "ts": now_epoch,
-                                "action": "update",
-                                "feature": "watchlist",
-                                "key": ak,
-                                "source": am.get("src", ""),
-                                "title": am.get("title", ""),
-                                "type": am.get("type", ""),
-                            }
-                        )
-                        break
-
-            for k in added_keys:
-                m = cur_wl.get(k) or {}
-                ev.append(
-                    {
-                        "ts": now_epoch,
-                        "action": "add",
-                        "feature": "watchlist",
-                        "key": k,
-                        "source": m.get("src", ""),
-                        "title": m.get("title", ""),
-                        "type": m.get("type", ""),
-                    }
-                )
-            for k in removed_keys:
-                m = prev_wl.get(k) or {}
-                ev.append(
-                    {
-                        "ts": now_epoch,
-                        "action": "remove",
-                        "feature": "watchlist",
-                        "key": k,
-                        "source": m.get("src", ""),
-                        "title": m.get("title", ""),
-                        "type": m.get("type", ""),
-                    }
-                )
+            added_keys, removed_keys = _emit_lane_events(ev, "watchlist", prev_wl, cur_wl, now_epoch)
 
             self.data["current"] = cur_wl
             counters = self._ensure_counters()
@@ -665,63 +670,7 @@ class Stats:
                 if not prev_map and not cur_map:
                     cur_by[feat] = {}
                     continue
-                ap, rp = set(cur_map), set(prev_map)
-                adds, rems = sorted(ap - rp), sorted(rp - ap)
-
-                for rk in list(rems):
-                    rm = prev_map.get(rk) or {}
-                    rp = _provset(rm)
-                    rp_name, rp_id = _idcore(rk)
-                    for ak in list(adds):
-                        am = cur_map.get(ak) or {}
-                        ap = _provset(am)
-                        ap_name, ap_id = _idcore(ak)
-                        same_title = _titles_match_loose(rm, am)
-                        same_idcore = (
-                            rp_name == ap_name and rp_id and ap_id and rp_id == ap_id
-                        )
-                        if (same_title or same_idcore) and (rp & ap or same_idcore):
-                            rems.remove(rk)
-                            adds.remove(ak)
-                            ev.append(
-                                {
-                                    "ts": now_epoch,
-                                    "action": "update",
-                                    "feature": feat,
-                                    "key": ak,
-                                    "source": am.get("src", ""),
-                                    "title": am.get("title", ""),
-                                    "type": am.get("type", ""),
-                                }
-                            )
-                            break
-
-                for k in adds:
-                    m = cur_map.get(k) or {}
-                    ev.append(
-                        {
-                            "ts": now_epoch,
-                            "action": "add",
-                            "feature": feat,
-                            "key": k,
-                            "source": m.get("src", ""),
-                            "title": m.get("title", ""),
-                            "type": m.get("type", ""),
-                        }
-                    )
-                for k in rems:
-                    m = prev_map.get(k) or {}
-                    ev.append(
-                        {
-                            "ts": now_epoch,
-                            "action": "remove",
-                            "feature": feat,
-                            "key": k,
-                            "source": m.get("src", ""),
-                            "title": m.get("title", ""),
-                            "type": m.get("type", ""),
-                        }
-                    )
+                _emit_lane_events(ev, feat, prev_map, cur_map, now_epoch)
                 cur_by[feat] = cur_map
 
             self.data["current_by_feature"] = cur_by

--- a/tests/test_shared_helpers_regression.py
+++ b/tests/test_shared_helpers_regression.py
@@ -213,6 +213,42 @@ def test_cfg_delete_enabled_type_not_in_allowed_list():
     assert _sink_common._cfg_delete_enabled(cfg, "movie") is False
 
 
+def test_cfg_num_reads_section_value_and_casts_to_default_type():
+    cfg = {"scrobble": {"trakt": {"stop_pause_threshold": "45"}}}
+    assert _sink_common._cfg_num(cfg, "trakt", "stop_pause_threshold", 30) == 45
+
+
+def test_cfg_num_missing_section_returns_default():
+    assert _sink_common._cfg_num({}, "trakt", "stop_pause_threshold", 30) == 30
+
+
+def test_cfg_num_none_value_falls_back_to_fallback_section():
+    cfg = {"scrobble": {"simkl": {"progress_step": None}, "trakt": {"progress_step": 5}}}
+    assert _sink_common._cfg_num(cfg, "simkl", "progress_step", 1, fallback_section="trakt") == 5
+
+
+def test_cfg_num_no_fallback_section_returns_default_when_absent():
+    cfg = {"scrobble": {"simkl": {}}}
+    assert _sink_common._cfg_num(cfg, "simkl", "progress_step", 1) == 1
+
+
+def test_cfg_num_explicit_value_wins_over_fallback_section():
+    cfg = {"scrobble": {"simkl": {"progress_step": 9}, "trakt": {"progress_step": 5}}}
+    assert _sink_common._cfg_num(cfg, "simkl", "progress_step", 1, fallback_section="trakt") == 9
+
+
+def test_cfg_num_non_numeric_value_returns_default():
+    cfg = {"scrobble": {"trakt": {"stop_pause_threshold": "not-a-number"}}}
+    assert _sink_common._cfg_num(cfg, "trakt", "stop_pause_threshold", 30) == 30
+
+
+@pytest.mark.parametrize("default,expected_type", [(30, int), (99.0, float)])
+def test_cfg_num_casts_to_type_of_default(default, expected_type):
+    cfg = {"scrobble": {"trakt": {"k": "12"}}}
+    out = _sink_common._cfg_num(cfg, "trakt", "k", default)
+    assert isinstance(out, expected_type)
+
+
 def test_extract_skeleton_from_body_strips_volatile_fields():
     body = {"progress": 50, "app_version": "1.0", "app_date": "x", "action": "start"}
     assert _sink_common._extract_skeleton_from_body(body) == {"action": "start"}

--- a/tests/test_sink_progress_resolution.py
+++ b/tests/test_sink_progress_resolution.py
@@ -1,0 +1,267 @@
+# tests/test_sink_progress_resolution.py
+# CrossWatch - characterization tests for the p_send/action resolution logic
+# shared (with real divergence, see module docstring) across the Trakt, SIMKL
+# and MDBList scrobble sinks.
+#
+# These tests pin down CURRENT behavior of TraktSink.send / SimklSink.send /
+# MDBListSink.send for the force_seek / start-floor / regress-tolerance
+# progress computation plus the suppress-start / complete-at / demote-STOP-
+# to-PAUSE logic. They exist as a safety net for a future extraction of a
+# shared `resolve_send_progress` helper; see the accompanying report for why
+# that extraction was not attempted in this pass (the divergence between
+# Trakt and SIMKL/MDBList in this area is materially larger than "one extra
+# branch" -- Trakt has two additional, send()-terminating early-return
+# branches with their own state-mutation side effects that SIMKL/MDBList do
+# not have at all).
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import providers.scrobble.mdblist.sink as mdblist_mod
+import providers.scrobble.simkl.sink as simkl_mod
+import providers.scrobble.trakt.sink as trakt_mod
+from providers.scrobble.scrobble import ScrobbleEvent
+
+SK = "sess1"
+MK = "tmdb:100"  # _mkey() output for ids={"tmdb": "100"}, media_type="movie" -- identical across all 3 sinks
+
+
+def make_event(
+    action: str,
+    progress: int,
+    *,
+    media_type: str = "movie",
+    raw: dict[str, Any] | None = None,
+    session_key: str = SK,
+    ids: dict[str, Any] | None = None,
+) -> ScrobbleEvent:
+    return ScrobbleEvent(
+        action=action,  # type: ignore[arg-type]
+        media_type=media_type,  # type: ignore[arg-type]
+        ids=ids or {"tmdb": "100"},
+        title="Test Movie",
+        year=2020,
+        season=None,
+        number=None,
+        progress=progress,
+        account="user",
+        server_uuid="srv-1",
+        session_key=session_key,
+        raw=raw or {},
+    )
+
+
+def make_cfg(kind: str, **overrides: Any) -> dict[str, Any]:
+    """Build a minimal cfg for `kind` in {"trakt","simkl","mdblist"}.
+
+    Per-sink getter fallback chains (verified by reading each sink's source,
+    not assumed):
+      - trakt reads scrobble.trakt.<key> directly.
+      - simkl reads scrobble.simkl.<key>, falling back to scrobble.trakt.<key>.
+      - mdblist's stop_pause_threshold/force_stop_at/complete_at/
+        regress_tolerance_percent read scrobble.trakt.<key> directly (no
+        scrobble.mdblist check at all); only progress_step checks
+        scrobble.mdblist.<key> first.
+    """
+    settings = {
+        "stop_pause_threshold": 85,
+        "force_stop_at": 95,
+        "complete_at": 0,
+        "regress_tolerance_percent": 5,
+        "progress_step": 1,
+    }
+    settings.update(overrides)
+    scrobble: dict[str, Any] = {"watch": {"pause_debounce_seconds": 5, "suppress_start_at": 99}}
+    if kind == "trakt":
+        scrobble["trakt"] = dict(settings)
+        return {"scrobble": scrobble, "trakt": {"client_id": "cid", "access_token": "tok"}}
+    if kind == "simkl":
+        scrobble["simkl"] = dict(settings)
+        return {"scrobble": scrobble, "simkl": {"api_key": "key", "access_token": "tok"}}
+    if kind == "mdblist":
+        scrobble["trakt"] = dict(settings)
+        return {"scrobble": scrobble, "mdblist": {"api_key": "key"}}
+    raise ValueError(kind)
+
+
+def _make_sink(monkeypatch: pytest.MonkeyPatch, kind: str):
+    """Instantiate a sink with HTTP and recording fully mocked out.
+
+    Returns (sink, captured, events):
+      - captured: list of {"path", "body"} for every _send_http call that
+        would have hit the network.
+      - events["stop_recorded"]: list of kwargs passed to record_scrobble_event.
+    """
+    captured: list[dict[str, Any]] = []
+    events: dict[str, list[dict[str, Any]]] = {"stop_recorded": []}
+
+    def fake_record(ev: Any, **kw: Any) -> None:
+        events["stop_recorded"].append(kw)
+
+    if kind == "trakt":
+        sink = trakt_mod.TraktSink(instance_id="default")
+
+        def fake_send_http(path: str, body: dict[str, Any], cfg: dict[str, Any]) -> dict[str, Any]:
+            captured.append({"path": path, "body": body})
+            return {"ok": True, "status": 201, "resp": {"action": path.rsplit("/", 1)[-1]}}
+
+        monkeypatch.setattr(sink, "_send_http", fake_send_http)
+        monkeypatch.setattr(trakt_mod, "record_scrobble_event", fake_record)
+    elif kind == "simkl":
+        sink = simkl_mod.SimklSink(instance_id="default")
+
+        def fake_send_http(path: str, body: dict[str, Any], cfg: dict[str, Any]) -> dict[str, Any]:
+            captured.append({"path": path, "body": body})
+            return {"ok": True, "status": 201, "resp": {"action": path.rsplit("/", 1)[-1]}}
+
+        monkeypatch.setattr(sink, "_send_http", fake_send_http)
+        monkeypatch.setattr(simkl_mod, "record_scrobble_event", fake_record)
+    elif kind == "mdblist":
+        sink = mdblist_mod.MDBListSink(instance_id="default")
+
+        def fake_send_http(path: str, body: dict[str, Any], api_key: str, cfg: dict[str, Any]) -> dict[str, Any]:
+            captured.append({"path": path, "body": body})
+            return {"ok": True, "status": 201, "resp": {"action": path.rsplit("/", 1)[-1]}}
+
+        monkeypatch.setattr(sink, "_send_http", fake_send_http)
+        monkeypatch.setattr(mdblist_mod, "record_scrobble_event", fake_record)
+
+        class _FakeAuth:
+            def is_configured(self, *_a: Any, **_k: Any) -> bool:
+                return True
+
+        monkeypatch.setattr(mdblist_mod, "_provider_auth", lambda: _FakeAuth())
+    else:
+        raise ValueError(kind)
+
+    return sink, captured, events
+
+
+def _seed(sink: Any, session_key: str, mk: str, *, p_sess: int | None = None, p_glob: int | None = None, last_act: str | None = None) -> None:
+    key = (session_key, mk)
+    if p_sess is not None:
+        sink._p_sess[key] = p_sess
+    if p_glob is not None:
+        sink._p_glob[mk] = p_glob
+    if last_act is not None:
+        sink._a_sess[key] = last_act
+
+
+SINK_KINDS = ["trakt", "simkl", "mdblist"]
+
+
+@pytest.mark.parametrize("kind", SINK_KINDS)
+def test_normal_progress_advance(monkeypatch, config_base, kind):
+    sink, captured, _events = _make_sink(monkeypatch, kind)
+    _seed(sink, SK, MK, p_sess=30, last_act="pause")
+    cfg = make_cfg(kind)
+    sink.send(make_event("pause", 45), cfg)
+    assert len(captured) == 1
+    assert captured[0]["path"].endswith("/pause")
+    assert captured[0]["body"]["progress"] == 45
+
+
+@pytest.mark.parametrize("kind", SINK_KINDS)
+def test_regression_within_tolerance_holds_prior_progress(monkeypatch, config_base, kind):
+    # tol=5 (default); p_sess=50, p_now=47 -> regression of 3 is within
+    # tolerance, so the sink holds at the prior (higher) session progress.
+    sink, captured, _events = _make_sink(monkeypatch, kind)
+    _seed(sink, SK, MK, p_sess=50, last_act="pause")
+    cfg = make_cfg(kind)
+    sink.send(make_event("pause", 47), cfg)
+    assert len(captured) == 1
+    assert captured[0]["body"]["progress"] == 50
+
+
+@pytest.mark.parametrize("kind", SINK_KINDS)
+def test_regression_beyond_tolerance_applies_lower_value(monkeypatch, config_base, kind):
+    # p_sess=50, p_now=40 -> regression of 10 exceeds tol=5, so the lower
+    # (actual) progress is sent.
+    sink, captured, _events = _make_sink(monkeypatch, kind)
+    _seed(sink, SK, MK, p_sess=50, last_act="pause")
+    cfg = make_cfg(kind)
+    sink.send(make_event("pause", 40), cfg)
+    assert len(captured) == 1
+    assert captured[0]["body"]["progress"] == 40
+
+
+@pytest.mark.parametrize("kind", SINK_KINDS)
+def test_force_seek_bypasses_tolerance(monkeypatch, config_base, kind):
+    # _cw_seek=True makes p_send == p_now unconditionally for non-start
+    # actions, even though p_sess=80 would otherwise hold/clamp a jump down to 20.
+    sink, captured, _events = _make_sink(monkeypatch, kind)
+    _seed(sink, SK, MK, p_sess=80, last_act="pause")
+    cfg = make_cfg(kind)
+    sink.send(make_event("pause", 20, raw={"_cw_seek": True}), cfg)
+    assert len(captured) == 1
+    assert captured[0]["body"]["progress"] == 20
+
+
+@pytest.mark.parametrize("kind", SINK_KINDS)
+def test_near_complete_stop_sends_and_records(monkeypatch, config_base, kind):
+    # p_send=97 >= force_stop_at=95 -> action stays "stop", is sent, and a
+    # completion event is recorded (gates auto-remove-from-watchlist).
+    sink, captured, events = _make_sink(monkeypatch, kind)
+    _seed(sink, SK, MK, p_sess=90, last_act="pause")
+    cfg = make_cfg(kind)
+    sink.send(make_event("stop", 97), cfg)
+    assert len(captured) == 1
+    assert captured[0]["path"].endswith("/stop")
+    assert captured[0]["body"]["progress"] == 97
+    assert len(events["stop_recorded"]) == 1
+    assert events["stop_recorded"][0]["progress"] == 97
+
+
+# --- Trakt-only branches ---------------------------------------------------
+#
+# Verified by reading all 3 files: Trakt has TWO extra send()-terminating
+# early-return branches that SIMKL/MDBList do not have at all (not just "one
+# extra 80%-cutoff branch" as assumed going in to this refactor):
+#   1. STOP below stop_pause_threshold but >= the 80% Trakt scrobble cutoff
+#      -> silently skipped (state recorded as "pause", nothing sent).
+#   2. PAUSE at/above min(stop_pause_threshold, 80%) -> rejected outright
+#      (Trakt's API 422s on /scrobble/pause above ~80%).
+# STOP below both threshold and the 80% cutoff is demoted to PAUSE and still
+# sent (this part *is* shared in spirit with SIMKL/MDBList's later
+# jump-demote block, but the 80%-anchored trigger condition is Trakt-only).
+
+def test_trakt_stop_between_cutoff_and_threshold_is_skipped_not_sent(monkeypatch, config_base):
+    sink, captured, _events = _make_sink(monkeypatch, "trakt")
+    cfg = make_cfg("trakt", stop_pause_threshold=90)
+    sink.send(make_event("stop", 85, raw={"_cw_seek": True}), cfg)
+    assert captured == []
+    assert sink._a_sess[(SK, MK)] == "pause"
+    assert sink._p_sess[(SK, MK)] == 85
+
+
+def test_trakt_stop_below_cutoff_is_demoted_to_pause_and_sent(monkeypatch, config_base):
+    sink, captured, _events = _make_sink(monkeypatch, "trakt")
+    cfg = make_cfg("trakt", stop_pause_threshold=90)
+    sink.send(make_event("stop", 70, raw={"_cw_seek": True}), cfg)
+    assert len(captured) == 1
+    assert captured[0]["path"].endswith("/pause")
+    assert captured[0]["body"]["progress"] == 70
+
+
+def test_trakt_pause_at_or_above_cutoff_is_rejected_not_sent(monkeypatch, config_base):
+    sink, captured, _events = _make_sink(monkeypatch, "trakt")
+    cfg = make_cfg("trakt", stop_pause_threshold=90)
+    sink.send(make_event("pause", 85, raw={"_cw_seek": True}), cfg)
+    assert captured == []
+    assert sink._a_sess[(SK, MK)] == "pause"
+
+
+@pytest.mark.parametrize("kind", ["simkl", "mdblist"])
+def test_simkl_and_mdblist_send_stop_unchanged_where_trakt_would_skip(monkeypatch, config_base, kind):
+    # Same cfg/progress as test_trakt_stop_between_cutoff_and_threshold_is_skipped_not_sent:
+    # SIMKL/MDBList have no 80%-cutoff concept at all, so they send the STOP
+    # unchanged instead of silently skipping it. This is the concrete proof
+    # of the divergence documented above.
+    sink, captured, _events = _make_sink(monkeypatch, kind)
+    cfg = make_cfg(kind, stop_pause_threshold=90)
+    sink.send(make_event("stop", 85, raw={"_cw_seek": True}), cfg)
+    assert len(captured) == 1
+    assert captured[0]["path"].endswith("/stop")
+    assert captured[0]["body"]["progress"] == 85


### PR DESCRIPTION
## Summary

Continues the simplification effort from #56. This is recovered work from a prior
Claude Code session that was killed mid-task before it could commit — I found ~23
uncommitted files sitting in its worktree, reviewed every hunk (four independent
parallel reviews split by area: API layer, orchestrator/services, scrobble sinks,
frontend JS), confirmed it's behavior-preserving, then committed it split into two
commits:

1. **`6abfe57`** — the recovered refactor itself (unmodified from what the killed
   session produced, after verification)
2. **`e748cfa`** — my own additions on top: direct regression tests for the new
   `_cfg_num` helper (the pre-existing test only exercised it incidentally and never
   hit its fallback-section path), plus finishing one small dedup the killed session
   missed (`setup-wizard/index.js` still had its own local copy of `_norm` instead of
   importing the shared one)

## What changed (commit 1)

- `api/configAPI.py`, `editorAPI.py`, `metaAPI.py`, `syncAPI.py` — extracted shared
  helpers for save/migrate normalization, manual policy/state read-write, art-cache
  lookup, and feature/baseline index iteration; removed one dead function
  (`get_poster_file`, zero remaining callers)
- `crosswatch.py` — one helper replaces 3 identical TTL-cached config-flag readers
- `cw_platform/config_base.py` — one helper replaces 4 near-identical rate-limit-clamp
  blocks
- `cw_platform/orchestrator/_unresolved.py` — shared file-scan/legacy-migration loop
- `services/scheduling.py` — shared busy-wait loop and status-reset helper
- `services/snapshots.py` — shared classify/history-diff helpers
- `services/statistics.py` — shared lane event-emission helper
- `providers/scrobble/_sink_common.py` + trakt/simkl/mdblist sinks — new `_cfg_num`
  helper replaces per-sink config-number parsing
- Several `assets/js` modals — shared credential-submit, route-modal-shell, sub-tab
  wiring, and config-save helpers replace inline duplication

## Verification

Every file was independently checked against its pre-refactor logic for: changed
conditionals/defaults, dropped error handling, missed call sites after extraction,
and provider-specific behavior accidentally collapsed into shared code. No issues
found beyond a couple of pre-existing (unrelated, untouched-by-this-diff) oddities
that got flagged and left alone.

Full test suite passes with the same 3 pre-existing unrelated failures present on
`main` (`test_dashboard_widgets`, `test_meta_api_episode_stills`,
`test_playback_progress` — confirmed identical with this diff stashed out).

No build step for the JS assets; syntax-checked all touched files with `node --check`.