### PR TITLE
refactor: collapse twoway's duplicated A/B apply-remove/update/add blocks

### DIFF
--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -1297,69 +1297,217 @@ def _two_way_sync(
         except Exception:
             pass
 
-    if rem_from_A:
-        if a_down:
-            record_unresolved(a, feature, rem_from_A, hint="provider_down:remove")
-            emit("writes:skipped", dst=a, feature=feature, reason="provider_down", op="remove", count=len(rem_from_A))
-        else:
-            emit("two:apply:remove:A:start", dst=a, feature=feature, count=len(rem_from_A))
-            resA_rem = apply_remove(
-                dst_ops=aops, cfg=provider_cfg, dst_name=a, feature=feature, items=rem_from_A,
-                dry_run=dry_run_flag, emit=emit, dbg=dbg,
-                chunk_size=effective_chunk_size(ctx, a), chunk_pause_ms=_pause_for(a),
-            )
-            prov_count_A = _confirmed(resA_rem)
-            if prov_count_A and not dry_run_flag:
-                removed_now = 0
-                for k in remA_keys:
-                    if k in A_eff:
-                        A_eff.pop(k, None)
-                        removed_now += 1
-                        if removed_now >= prov_count_A:
-                            break
-                _mark_tombs(rem_from_A)
-                _bust_snapshot(a)
+    # _apply_remove_side / _apply_update_side / _apply_add_side: side A and side B used
+    # to run near-identical copy-pasted blocks here (only names differed - a/b, aops/bops,
+    # A_eff/B_eff, etc; confirmed via a name-normalized diff before extracting). Each is
+    # called once per side below; being nested closures they still reach `feature`,
+    # `provider_cfg`, `dry_run_flag`, `emit`, `dbg`, `ctx`, `pair_key`, `cfg`,
+    # `verify_after_write`, `use_phantoms`, `_mark_tombs`, and `_bust_snapshot` from the
+    # enclosing scope exactly as the inline blocks did.
 
-            emit("two:apply:remove:A:done", dst=a, feature=feature,
-                 count=_confirmed(resA_rem),
-                 attempted=int(resA_rem.get("attempted", 0)),
-                 removed=_confirmed(resA_rem),
-                 skipped=int(resA_rem.get("skipped", 0)),
-                 unresolved=int(resA_rem.get("unresolved", 0)),
-                 errors=int(resA_rem.get("errors", 0)),
-                 result=resA_rem)
+    def _apply_remove_side(
+        side: str, ops: Any, name: str, down: bool,
+        items: list[dict[str, Any]], rem_keys: list[str], eff_index: dict[str, Any],
+    ) -> dict[str, Any]:
+        if down:
+            record_unresolved(name, feature, items, hint="provider_down:remove")
+            emit("writes:skipped", dst=name, feature=feature, reason="provider_down", op="remove", count=len(items))
+            return {"ok": True, "count": 0}
+
+        emit(f"two:apply:remove:{side}:start", dst=name, feature=feature, count=len(items))
+        res = apply_remove(
+            dst_ops=ops, cfg=provider_cfg, dst_name=name, feature=feature, items=items,
+            dry_run=dry_run_flag, emit=emit, dbg=dbg,
+            chunk_size=effective_chunk_size(ctx, name), chunk_pause_ms=_pause_for(name),
+        )
+        prov_count = _confirmed(res)
+        if prov_count and not dry_run_flag:
+            removed_now = 0
+            for k in rem_keys:
+                if k in eff_index:
+                    eff_index.pop(k, None)
+                    removed_now += 1
+                    if removed_now >= prov_count:
+                        break
+            _mark_tombs(items)
+            _bust_snapshot(name)
+
+        emit(f"two:apply:remove:{side}:done", dst=name, feature=feature,
+             count=_confirmed(res),
+             attempted=int(res.get("attempted", 0)),
+             removed=_confirmed(res),
+             skipped=int(res.get("skipped", 0)),
+             unresolved=int(res.get("unresolved", 0)),
+             errors=int(res.get("errors", 0)),
+             result=res)
+        return res
+
+    def _apply_update_side(
+        side: str, ops: Any, name: str, down: bool,
+        items: list[dict[str, Any]], eff_index: dict[str, Any],
+    ) -> tuple[dict[str, Any], int, int]:
+        if down:
+            record_unresolved(name, feature, items, hint="provider_down:update")
+            emit("writes:skipped", dst=name, feature=feature, reason="provider_down", op="update", count=len(items))
+            return {"ok": True, "count": 0}, 0, len(items)
+
+        emit(f"two:apply:update:{side}:start", dst=name, feature=feature, count=len(items))
+        unresolved_before = set(load_unresolved_keys(name, feature, cross_features=_cross_feature_unresolved(feature)) or [])
+        res = apply_update(
+            dst_ops=ops, cfg=provider_cfg, dst_name=name, feature=feature, items=items,
+            dry_run=dry_run_flag, emit=emit, dbg=dbg,
+            chunk_size=effective_chunk_size(ctx, name), chunk_pause_ms=_pause_for(name),
+        )
+        unresolved_after = set(load_unresolved_keys(name, feature, cross_features=_cross_feature_unresolved(feature)) or [])
+        prov_unresolved_keys_raw = (res or {}).get("unresolved_keys")
+        prov_unresolved_keys: list[str] = (
+            [str(x) for x in prov_unresolved_keys_raw if x] if isinstance(prov_unresolved_keys_raw, list) else []
+        )
+        new_unresolved = (unresolved_after - unresolved_before) | (set(prov_unresolved_keys) - unresolved_before)
+        eff = int((res or {}).get("confirmed", (res or {}).get("count", 0)) or 0)
+        if eff and not dry_run_flag:
+            upd_map = {(_ck(_minimal(it)) or ""): _minimal(it) for it in items}
+            confirmed_keys = [str(x) for x in ((res or {}).get("confirmed_keys") or []) if x]
+            keys_to_write = confirmed_keys if confirmed_keys else (list(upd_map.keys()) if eff >= len(upd_map) else [])
+            for k in keys_to_write:
+                v = upd_map.get(k)
+                if v:
+                    eff_index[k] = v
+            if keys_to_write:
+                _bust_snapshot(name)
+        emit(f"two:apply:update:{side}:done", dst=name, feature=feature,
+             count=eff,
+             attempted=int(res.get("attempted", 0)),
+             updated=eff,
+             skipped=int(res.get("skipped", 0)),
+             unresolved=int(res.get("unresolved", 0)),
+             errors=int(res.get("errors", 0)),
+             result=res)
+        return res, eff, len(new_unresolved)
+
+    def _apply_add_side(
+        side: str, ops: Any, name: str, down: bool,
+        items: list[dict[str, Any]], eff_index: dict[str, Any], guard: Any,
+    ) -> tuple[dict[str, Any], int, int]:
+        if down:
+            record_unresolved(name, feature, items, hint="provider_down:add")
+            emit("writes:skipped", dst=name, feature=feature, reason="provider_down", op="add", count=len(items))
+            return {"ok": True, "count": 0}, 0, len(items)
+
+        emit(f"two:apply:add:{side}:start", dst=name, feature=feature, count=len(items))
+        unresolved_before = set(load_unresolved_keys(name, feature, cross_features=_cross_feature_unresolved(feature)) or [])
+        _ = set(load_blackbox_keys(name, feature, pair=pair_key) or [])
+        attempted: list[str] = []
+        seen: set[str] = set()
+        k2i: dict[str, Any] = {}
+        for it in items:
+            k = _ck(_minimal(it))
+            if not k or k in seen:
+                continue
+            seen.add(k)
+            attempted.append(k)
+            k2i[k] = _minimal(it)
+
+        res = apply_add(
+            dst_ops=ops, cfg=provider_cfg, dst_name=name, feature=feature, items=items,
+            dry_run=dry_run_flag, emit=emit, dbg=dbg,
+            chunk_size=effective_chunk_size(ctx, name), chunk_pause_ms=_pause_for(name),
+        )
+        unresolved_after = set(load_unresolved_keys(name, feature, cross_features=_cross_feature_unresolved(feature)) or [])
+        prov_unresolved_keys_raw = (res or {}).get("unresolved_keys")
+        prov_unresolved_keys: list[str] = (
+            [str(x) for x in prov_unresolved_keys_raw if x] if isinstance(prov_unresolved_keys_raw, list) else []
+        )
+        prov_unresolved_set: set[str] = set(prov_unresolved_keys)
+
+        new_unresolved = (unresolved_after - unresolved_before) | (prov_unresolved_set - unresolved_before)
+        still_unresolved = set(attempted) & (unresolved_after | prov_unresolved_set)
+
+        prov_confirmed_keys_raw = (res or {}).get("confirmed_keys")
+        prov_skipped_keys_raw = (res or {}).get("skipped_keys")
+
+        prov_confirmed_keys: list[str] = (
+            [str(x) for x in prov_confirmed_keys_raw if x] if isinstance(prov_confirmed_keys_raw, list) else []
+        )
+        prov_skipped_keys: list[str] = (
+            [str(x) for x in prov_skipped_keys_raw if x] if isinstance(prov_skipped_keys_raw, list) else []
+        )
+
+        skipped_keys: set[str] = set(prov_skipped_keys)
+
+        have_exact_keys = bool(prov_confirmed_keys)
+        if have_exact_keys:
+            attempted_set = set(attempted)
+            confirmed = [k for k in prov_confirmed_keys if k in attempted_set]
+        else:
+            confirmed = [k for k in attempted if k not in still_unresolved]
+
+        prov_count = _confirmed(res)
+        if have_exact_keys:
+            prov_count = min(prov_count or len(confirmed), len(confirmed))
+
+        ambiguous_partial = False
+        if verify_after_write and _apply_verify_after_write_supported(ops):
+            try:
+                unresolved_again = set(load_unresolved_keys(name, feature, cross_features=_cross_feature_unresolved(feature)) or [])
+                confirmed = [k for k in confirmed if k not in unresolved_again]
+            except Exception:
+                pass
+            eff = len(confirmed)
+        else:
+            ambiguous_partial = (not have_exact_keys) and bool((res or {}).get("skipped")) and prov_count and (prov_count < len(confirmed))
+            eff = 0 if still_unresolved or ambiguous_partial else min(prov_count, len(confirmed))
+
+        if eff != prov_count and not have_exact_keys:
+            dbg("two:apply:add:corrected", dst=name, feature=feature,
+                provider_count=prov_count, effective=eff, newly_unresolved=len(new_unresolved))
+
+        success = confirmed if (verify_after_write or have_exact_keys) else confirmed[:eff]
+        try:
+            failed = [k for k in attempted if k not in set(success) and k not in skipped_keys]
+            if failed and not ambiguous_partial:
+                record_attempts(name, feature, failed,
+                    reason="two:apply:add:failed", op="add",
+                    pair=pair_key, cfg=cfg)
+                failed_items = [k2i[k] for k in failed if k in k2i]
+                if failed_items:
+                    record_unresolved(name, feature, failed_items, hint="apply:add:failed")
+
+            if success:
+                record_success(name, feature, success, pair=pair_key, cfg=cfg)
+                clear_items_for_feature(
+                    ctx.state_store,
+                    dbg,
+                    feature,
+                    [k2i[k] for k in success if k in k2i],
+                    pair=pair_key,
+                )
+            if use_phantoms and guard and success:
+                guard.record_success(set(success))
+        except Exception:
+            pass
+
+        if success and not dry_run_flag:
+            for k in success:
+                v = k2i.get(k)
+                if v:
+                    eff_index[k] = v
+            _bust_snapshot(name)
+        emit(f"two:apply:add:{side}:done", dst=name, feature=feature,
+             count=_confirmed(res),
+             attempted=int(res.get("attempted", 0)),
+             added=_confirmed(res),
+             skipped=int(res.get("skipped", 0)),
+             unresolved=int(res.get("unresolved", 0)),
+             errors=int(res.get("errors", 0)),
+             result=res)
+        return res, eff, len(new_unresolved)
+
+    if rem_from_A:
+        resA_rem = _apply_remove_side("A", aops, a, a_down, rem_from_A, remA_keys, A_eff)
 
     if rem_from_B:
-        if b_down:
-            record_unresolved(b, feature, rem_from_B, hint="provider_down:remove")
-            emit("writes:skipped", dst=b, feature=feature, reason="provider_down", op="remove", count=len(rem_from_B))
-        else:
-            emit("two:apply:remove:B:start", dst=b, feature=feature, count=len(rem_from_B))
-            resB_rem = apply_remove(
-                dst_ops=bops, cfg=provider_cfg, dst_name=b, feature=feature, items=rem_from_B,
-                dry_run=dry_run_flag, emit=emit, dbg=dbg,
-                chunk_size=effective_chunk_size(ctx, b), chunk_pause_ms=_pause_for(b),
-            )
-            prov_count_B = _confirmed(resB_rem)
-            if prov_count_B and not dry_run_flag:
-                removed_now = 0
-                for k in remB_keys:
-                    if k in B_eff:
-                        B_eff.pop(k, None)
-                        removed_now += 1
-                        if removed_now >= prov_count_B:
-                            break
-                _mark_tombs(rem_from_B)
-                _bust_snapshot(b)
-
-            emit("two:apply:remove:B:done", dst=b, feature=feature,
-                 count=_confirmed(resB_rem),
-                 attempted=int(resB_rem.get("attempted", 0)),
-                 removed=_confirmed(resB_rem),
-                 skipped=int(resB_rem.get("skipped", 0)),
-                 unresolved=int(resB_rem.get("unresolved", 0)),
-                 errors=int(resB_rem.get("errors", 0)),
-                 result=resB_rem)
+        resB_rem = _apply_remove_side("B", bops, b, b_down, rem_from_B, remB_keys, B_eff)
 
     resA_add: dict[str, Any] = {"ok": True, "count": 0}
     resB_add: dict[str, Any] = {"ok": True, "count": 0}
@@ -1373,316 +1521,20 @@ def _two_way_sync(
     unresolved_new_B_total = 0
 
     if upd_to_A:
-        if a_down:
-            record_unresolved(a, feature, upd_to_A, hint="provider_down:update")
-            emit("writes:skipped", dst=a, feature=feature, reason="provider_down", op="update", count=len(upd_to_A))
-            unresolved_new_A_total += len(upd_to_A)
-        else:
-            emit("two:apply:update:A:start", dst=a, feature=feature, count=len(upd_to_A))
-            unresolved_before_A = set(load_unresolved_keys(a, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-            resA_upd = apply_update(
-                dst_ops=aops, cfg=provider_cfg, dst_name=a, feature=feature, items=upd_to_A,
-                dry_run=dry_run_flag, emit=emit, dbg=dbg,
-                chunk_size=effective_chunk_size(ctx, a), chunk_pause_ms=_pause_for(a),
-            )
-            unresolved_after_A = set(load_unresolved_keys(a, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-            prov_unresolved_keys_A_raw = (resA_upd or {}).get("unresolved_keys")
-            prov_unresolved_keys_A: list[str] = (
-                [str(x) for x in prov_unresolved_keys_A_raw if x] if isinstance(prov_unresolved_keys_A_raw, list) else []
-            )
-            new_unresolved_A = (unresolved_after_A - unresolved_before_A) | (set(prov_unresolved_keys_A) - unresolved_before_A)
-            unresolved_new_A_total += len(new_unresolved_A)
-            eff_upd_A = int((resA_upd or {}).get("confirmed", (resA_upd or {}).get("count", 0)) or 0)
-            if eff_upd_A and not dry_run_flag:
-                upd_map_A = {(_ck(_minimal(it)) or ""): _minimal(it) for it in upd_to_A}
-                confirmed_keys_A = [str(x) for x in ((resA_upd or {}).get("confirmed_keys") or []) if x]
-                keys_to_write_A = confirmed_keys_A if confirmed_keys_A else (list(upd_map_A.keys()) if eff_upd_A >= len(upd_map_A) else [])
-                for k in keys_to_write_A:
-                    v = upd_map_A.get(k)
-                    if v:
-                        A_eff[k] = v
-                if keys_to_write_A:
-                    _bust_snapshot(a)
-            emit("two:apply:update:A:done", dst=a, feature=feature,
-                 count=eff_upd_A,
-                 attempted=int(resA_upd.get("attempted", 0)),
-                 updated=eff_upd_A,
-                 skipped=int(resA_upd.get("skipped", 0)),
-                 unresolved=int(resA_upd.get("unresolved", 0)),
-                 errors=int(resA_upd.get("errors", 0)),
-                 result=resA_upd)
+        resA_upd, eff_upd_A, new_unres = _apply_update_side("A", aops, a, a_down, upd_to_A, A_eff)
+        unresolved_new_A_total += new_unres
 
     if upd_to_B:
-        if b_down:
-            record_unresolved(b, feature, upd_to_B, hint="provider_down:update")
-            emit("writes:skipped", dst=b, feature=feature, reason="provider_down", op="update", count=len(upd_to_B))
-            unresolved_new_B_total += len(upd_to_B)
-        else:
-            emit("two:apply:update:B:start", dst=b, feature=feature, count=len(upd_to_B))
-            unresolved_before_B = set(load_unresolved_keys(b, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-            resB_upd = apply_update(
-                dst_ops=bops, cfg=provider_cfg, dst_name=b, feature=feature, items=upd_to_B,
-                dry_run=dry_run_flag, emit=emit, dbg=dbg,
-                chunk_size=effective_chunk_size(ctx, b), chunk_pause_ms=_pause_for(b),
-            )
-            unresolved_after_B = set(load_unresolved_keys(b, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-            prov_unresolved_keys_B_raw = (resB_upd or {}).get("unresolved_keys")
-            prov_unresolved_keys_B: list[str] = (
-                [str(x) for x in prov_unresolved_keys_B_raw if x] if isinstance(prov_unresolved_keys_B_raw, list) else []
-            )
-            new_unresolved_B = (unresolved_after_B - unresolved_before_B) | (set(prov_unresolved_keys_B) - unresolved_before_B)
-            unresolved_new_B_total += len(new_unresolved_B)
-            eff_upd_B = int((resB_upd or {}).get("confirmed", (resB_upd or {}).get("count", 0)) or 0)
-            if eff_upd_B and not dry_run_flag:
-                upd_map_B = {(_ck(_minimal(it)) or ""): _minimal(it) for it in upd_to_B}
-                confirmed_keys_B = [str(x) for x in ((resB_upd or {}).get("confirmed_keys") or []) if x]
-                keys_to_write_B = confirmed_keys_B if confirmed_keys_B else (list(upd_map_B.keys()) if eff_upd_B >= len(upd_map_B) else [])
-                for k in keys_to_write_B:
-                    v = upd_map_B.get(k)
-                    if v:
-                        B_eff[k] = v
-                if keys_to_write_B:
-                    _bust_snapshot(b)
-            emit("two:apply:update:B:done", dst=b, feature=feature,
-                 count=eff_upd_B,
-                 attempted=int(resB_upd.get("attempted", 0)),
-                 updated=eff_upd_B,
-                 skipped=int(resB_upd.get("skipped", 0)),
-                 unresolved=int(resB_upd.get("unresolved", 0)),
-                 errors=int(resB_upd.get("errors", 0)),
-                 result=resB_upd)
+        resB_upd, eff_upd_B, new_unres = _apply_update_side("B", bops, b, b_down, upd_to_B, B_eff)
+        unresolved_new_B_total += new_unres
 
     if add_to_A:
-        if a_down:
-            record_unresolved(a, feature, add_to_A, hint="provider_down:add")
-            emit("writes:skipped", dst=a, feature=feature, reason="provider_down", op="add", count=len(add_to_A))
-            unresolved_new_A_total += len(add_to_A)
-        else:
-            emit("two:apply:add:A:start", dst=a, feature=feature, count=len(add_to_A))
-            unresolved_before_A = set(load_unresolved_keys(a, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-            _ = set(load_blackbox_keys(a, feature, pair=pair_key) or [])
-            attempted_A: list[str] = []
-            seen_A: set[str] = set()
-            k2i_A: dict[str, Any] = {}
-            for it in add_to_A:
-                k = _ck(_minimal(it))
-                if not k or k in seen_A:
-                    continue
-                seen_A.add(k)
-                attempted_A.append(k)
-                k2i_A[k] = _minimal(it)
-            
-            resA_add = apply_add(
-                dst_ops=aops, cfg=provider_cfg, dst_name=a, feature=feature, items=add_to_A,
-                dry_run=dry_run_flag, emit=emit, dbg=dbg,
-                chunk_size=effective_chunk_size(ctx, a), chunk_pause_ms=_pause_for(a),
-            )
-            unresolved_after_A = set(load_unresolved_keys(a, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-            prov_unresolved_keys_A_raw = (resA_add or {}).get("unresolved_keys")
-            prov_unresolved_keys_A: list[str] = (
-                [str(x) for x in prov_unresolved_keys_A_raw if x] if isinstance(prov_unresolved_keys_A_raw, list) else []
-            )
-            prov_unresolved_set_A: set[str] = set(prov_unresolved_keys_A)
-
-            new_unresolved_A = (unresolved_after_A - unresolved_before_A) | (prov_unresolved_set_A - unresolved_before_A)
-            unresolved_new_A_total += len(new_unresolved_A)
-            still_unresolved_A = set(attempted_A) & (unresolved_after_A | prov_unresolved_set_A)
-            
-            prov_confirmed_keys_A_raw = (resA_add or {}).get("confirmed_keys")
-            prov_skipped_keys_A_raw = (resA_add or {}).get("skipped_keys")
-
-            prov_confirmed_keys_A: list[str] = (
-                [str(x) for x in prov_confirmed_keys_A_raw if x] if isinstance(prov_confirmed_keys_A_raw, list) else []
-            )
-            prov_skipped_keys_A: list[str] = (
-                [str(x) for x in prov_skipped_keys_A_raw if x] if isinstance(prov_skipped_keys_A_raw, list) else []
-            )
-
-            skipped_keys_A: set[str] = set(prov_skipped_keys_A)
-
-            have_exact_keys_A = bool(prov_confirmed_keys_A)
-            if have_exact_keys_A:
-                attempted_set_A = set(attempted_A)
-                confirmed_A = [k for k in prov_confirmed_keys_A if k in attempted_set_A]
-            else:
-                confirmed_A = [k for k in attempted_A if k not in still_unresolved_A]
-
-        
-            prov_count_A = _confirmed(resA_add)
-            if have_exact_keys_A:
-                prov_count_A = min(prov_count_A or len(confirmed_A), len(confirmed_A))
-            
-            ambiguous_partial_A = False
-            if verify_after_write and _apply_verify_after_write_supported(aops):
-                try:
-                    unresolved_again = set(load_unresolved_keys(a, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-                    confirmed_A = [k for k in confirmed_A if k not in unresolved_again]
-                except Exception:
-                    pass
-                eff_add_A = len(confirmed_A)
-            else:
-                ambiguous_partial_A = (not have_exact_keys_A) and bool((resA_add or {}).get("skipped")) and prov_count_A and (prov_count_A < len(confirmed_A))
-                eff_add_A = 0 if still_unresolved_A or ambiguous_partial_A else min(prov_count_A, len(confirmed_A))
-            
-            if eff_add_A != prov_count_A and not have_exact_keys_A:
-                dbg("two:apply:add:corrected", dst=a, feature=feature,
-                    provider_count=prov_count_A, effective=eff_add_A, newly_unresolved=len(new_unresolved_A))
-            
-            success_A = confirmed_A if (verify_after_write or have_exact_keys_A) else confirmed_A[:eff_add_A]
-            try:
-                failed_A = [k for k in attempted_A if k not in set(success_A) and k not in skipped_keys_A]
-                if failed_A and not ambiguous_partial_A:
-                    record_attempts(a, feature, failed_A,
-                        reason="two:apply:add:failed", op="add",
-                        pair=pair_key, cfg=cfg)
-                    failed_items_A = [k2i_A[k] for k in failed_A if k in k2i_A]
-                    if failed_items_A:
-                        record_unresolved(a, feature, failed_items_A, hint="apply:add:failed")
-            
-                if success_A:
-                    record_success(a, feature, success_A, pair=pair_key, cfg=cfg)
-                    clear_items_for_feature(
-                        ctx.state_store,
-                        dbg,
-                        feature,
-                        [k2i_A[k] for k in success_A if k in k2i_A],
-                        pair=pair_key,
-                    )
-                if use_phantoms and guardA and success_A:
-                    guardA.record_success(set(success_A))
-            except Exception:
-                pass
-            
-            if success_A and not dry_run_flag:
-                for k in success_A:
-                    v = k2i_A.get(k)
-                    if v:
-                        A_eff[k] = v
-                _bust_snapshot(a)
-            emit("two:apply:add:A:done", dst=a, feature=feature,
-                 count=_confirmed(resA_add),
-                 attempted=int(resA_add.get("attempted", 0)),
-                 added=_confirmed(resA_add),
-                 skipped=int(resA_add.get("skipped", 0)),
-                 unresolved=int(resA_add.get("unresolved", 0)),
-                 errors=int(resA_add.get("errors", 0)),
-                 result=resA_add)
+        resA_add, eff_add_A, new_unres = _apply_add_side("A", aops, a, a_down, add_to_A, A_eff, guardA)
+        unresolved_new_A_total += new_unres
 
     if add_to_B:
-        if b_down:
-            record_unresolved(b, feature, add_to_B, hint="provider_down:add")
-            emit("writes:skipped", dst=b, feature=feature, reason="provider_down", op="add", count=len(add_to_B))
-            unresolved_new_B_total += len(add_to_B)
-        else:
-            emit("two:apply:add:B:start", dst=b, feature=feature, count=len(add_to_B))
-            unresolved_before_B = set(load_unresolved_keys(b, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-            _ = set(load_blackbox_keys(b, feature, pair=pair_key) or [])
-            attempted_B: list[str] = []
-            seen_B: set[str] = set()
-            k2i_B: dict[str, Any] = {}
-            for it in add_to_B:
-                k = _ck(_minimal(it))
-                if not k or k in seen_B:
-                    continue
-                seen_B.add(k)
-                attempted_B.append(k)
-                k2i_B[k] = _minimal(it)
-            
-            resB_add = apply_add(
-                dst_ops=bops, cfg=provider_cfg, dst_name=b, feature=feature, items=add_to_B,
-                dry_run=dry_run_flag, emit=emit, dbg=dbg,
-                chunk_size=effective_chunk_size(ctx, b), chunk_pause_ms=_pause_for(b),
-            )
-            unresolved_after_B = set(load_unresolved_keys(b, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-            prov_unresolved_keys_B_raw = (resB_add or {}).get("unresolved_keys")
-            prov_unresolved_keys_B: list[str] = (
-                [str(x) for x in prov_unresolved_keys_B_raw if x] if isinstance(prov_unresolved_keys_B_raw, list) else []
-            )
-            prov_unresolved_set_B: set[str] = set(prov_unresolved_keys_B)
-
-            new_unresolved_B = (unresolved_after_B - unresolved_before_B) | (prov_unresolved_set_B - unresolved_before_B)
-            unresolved_new_B_total += len(new_unresolved_B)
-            still_unresolved_B = set(attempted_B) & (unresolved_after_B | prov_unresolved_set_B)
-            
-            prov_confirmed_keys_B_raw = (resB_add or {}).get("confirmed_keys")
-            prov_skipped_keys_B_raw = (resB_add or {}).get("skipped_keys")
-
-            prov_confirmed_keys_B: list[str] = (
-                [str(x) for x in prov_confirmed_keys_B_raw if x] if isinstance(prov_confirmed_keys_B_raw, list) else []
-            )
-            prov_skipped_keys_B: list[str] = (
-                [str(x) for x in prov_skipped_keys_B_raw if x] if isinstance(prov_skipped_keys_B_raw, list) else []
-            )
-
-            skipped_keys_B: set[str] = set(prov_skipped_keys_B)
-
-            have_exact_keys_B = bool(prov_confirmed_keys_B)
-            if have_exact_keys_B:
-                attempted_set_B = set(attempted_B)
-                confirmed_B = [k for k in prov_confirmed_keys_B if k in attempted_set_B]
-            else:
-                confirmed_B = [k for k in attempted_B if k not in still_unresolved_B]
-
-        
-            prov_count_B = _confirmed(resB_add)
-            if have_exact_keys_B:
-                prov_count_B = min(prov_count_B or len(confirmed_B), len(confirmed_B))
-            
-            ambiguous_partial_B = False
-            if verify_after_write and _apply_verify_after_write_supported(bops):
-                try:
-                    unresolved_again = set(load_unresolved_keys(b, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-                    confirmed_B = [k for k in confirmed_B if k not in unresolved_again]
-                except Exception:
-                    pass
-                eff_add_B = len(confirmed_B)
-            else:
-                ambiguous_partial_B = (not have_exact_keys_B) and bool((resB_add or {}).get("skipped")) and prov_count_B and (prov_count_B < len(confirmed_B))
-                eff_add_B = 0 if still_unresolved_B or ambiguous_partial_B else min(prov_count_B, len(confirmed_B))
-            
-            if eff_add_B != prov_count_B and not have_exact_keys_B:
-                dbg("two:apply:add:corrected", dst=b, feature=feature,
-                    provider_count=prov_count_B, effective=eff_add_B, newly_unresolved=len(new_unresolved_B))
-            
-            success_B = confirmed_B if (verify_after_write or have_exact_keys_B) else confirmed_B[:eff_add_B]
-            try:
-                failed_B = [k for k in attempted_B if k not in set(success_B) and k not in skipped_keys_B]
-                if failed_B and not ambiguous_partial_B:
-                    record_attempts(b, feature, failed_B,
-                        reason="two:apply:add:failed", op="add",
-                        pair=pair_key, cfg=cfg)
-                    failed_items_B = [k2i_B[k] for k in failed_B if k in k2i_B]
-                    if failed_items_B:
-                        record_unresolved(b, feature, failed_items_B, hint="apply:add:failed")
-            
-                if success_B:
-                    record_success(b, feature, success_B, pair=pair_key, cfg=cfg)
-                    clear_items_for_feature(
-                        ctx.state_store,
-                        dbg,
-                        feature,
-                        [k2i_B[k] for k in success_B if k in k2i_B],
-                        pair=pair_key,
-                    )
-                if use_phantoms and guardB and success_B:
-                    guardB.record_success(set(success_B))
-            except Exception:
-                pass
-            
-            if success_B and not dry_run_flag:
-                for k in success_B:
-                    v = k2i_B.get(k)
-                    if v:
-                        B_eff[k] = v
-                _bust_snapshot(b)
-            emit("two:apply:add:B:done", dst=b, feature=feature,
-                 count=_confirmed(resB_add),
-                 attempted=int(resB_add.get("attempted", 0)),
-                 added=_confirmed(resB_add),
-                 skipped=int(resB_add.get("skipped", 0)),
-                 unresolved=int(resB_add.get("unresolved", 0)),
-                 errors=int(resB_add.get("errors", 0)),
-                 result=resB_add)
+        resB_add, eff_add_B, new_unres = _apply_add_side("B", bops, b, b_down, add_to_B, B_eff, guardB)
+        unresolved_new_B_total += new_unres
 
     try:
         st = ctx.state_store.load_state() or {}

--- a/tests/test_twoway_apply_sides.py
+++ b/tests/test_twoway_apply_sides.py
@@ -16,6 +16,17 @@ import pytest
 
 from cw_platform.id_map import canonical_key
 from cw_platform.orchestrator import _pairs_twoway as twoway
+from cw_platform.orchestrator import _unresolved
+
+
+@pytest.fixture(autouse=True)
+def _isolate_unresolved_state(monkeypatch, tmp_path):
+    # record_unresolved/load_unresolved_keys persist to a hardcoded STATE_DIR
+    # (see _unresolved.py), not the per-test CONFIG_BASE. Without this, tests
+    # that don't mock record_unresolved (e.g. the verify_after_write case)
+    # write real state that leaks into later tests reading the same path -
+    # same isolation pattern as tests/test_history_specials.py.
+    monkeypatch.setattr(_unresolved, "STATE_DIR", tmp_path)
 
 
 class _StateStore:

--- a/tests/test_twoway_apply_sides.py
+++ b/tests/test_twoway_apply_sides.py
@@ -1,0 +1,356 @@
+# tests/test_twoway_apply_sides.py
+# Characterization coverage for the apply-remove/apply-update/apply-add phases inside
+# cw_platform/orchestrator/_pairs_twoway.py's _two_way_sync, written before collapsing
+# the per-side (A/B) duplicated blocks into shared same-file helpers. A `sed`-normalized
+# diff confirmed the A and B blocks are pure mechanical mirrors (only names differ:
+# a/b, aops/bops, A_eff/B_eff, resA_*/resB_*, etc.) - these tests pin the actual
+# behavior of both sides, including paths that had zero prior direct coverage:
+# apply-update (never exercised before), provider-down handling for update/add, and
+# the have_exact_keys / ambiguous_partial / verify_after_write branches of apply-add.
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from cw_platform.id_map import canonical_key
+from cw_platform.orchestrator import _pairs_twoway as twoway
+
+
+class _StateStore:
+    def __init__(self, state: dict[str, Any] | None = None) -> None:
+        self.state: dict[str, Any] = state or {}
+        self.tomb: dict[str, Any] = {}
+
+    def load_state(self) -> dict[str, Any]:
+        return self.state
+
+    def save_state(self, value: dict[str, Any]) -> None:
+        self.state = value
+
+    def load_tomb(self) -> dict[str, Any]:
+        return self.tomb
+
+    def save_tomb(self, value: dict[str, Any]) -> None:
+        self.tomb = value
+
+
+class _Ops:
+    """Configurable fake provider ops. Each of add/update/remove can be overridden
+    with a callable(items) -> response_dict; defaults to a plain confirmed-all response."""
+
+    def __init__(self, add_fn=None, update_fn=None, remove_fn=None, caps: dict[str, Any] | None = None) -> None:
+        self.added: list[dict[str, Any]] = []
+        self.updated: list[dict[str, Any]] = []
+        self.removed: list[dict[str, Any]] = []
+        self._add_fn = add_fn
+        self._update_fn = update_fn
+        self._remove_fn = remove_fn
+        self._caps = caps or {"history": {"observed_deletes": False}, "ratings": {"observed_deletes": False}}
+
+    def add(self, _cfg, items, *, feature, dry_run=False):
+        self.added.extend(dict(item) for item in items)
+        if self._add_fn:
+            return self._add_fn(items)
+        return {
+            "ok": True,
+            "count": len(items),
+            "confirmed_keys": [canonical_key(item) for item in items],
+        }
+
+    def update(self, _cfg, items, *, feature, dry_run=False):
+        self.updated.extend(dict(item) for item in items)
+        if self._update_fn:
+            return self._update_fn(items)
+        return {
+            "ok": True,
+            "count": len(items),
+            "confirmed_keys": [canonical_key(item) for item in items],
+        }
+
+    def remove(self, _cfg, items, *, feature, dry_run=False):
+        self.removed.extend(dict(item) for item in items)
+        if self._remove_fn:
+            return self._remove_fn(items)
+        return {"ok": True, "count": len(items), "confirmed_keys": [canonical_key(item) for item in items]}
+
+    def capabilities(self):
+        return self._caps
+
+
+def _install_common_monkeypatches(monkeypatch, *, allow_adds: bool, allow_removals: bool) -> None:
+    monkeypatch.setattr(twoway, "_supports_feature", lambda _ops, _feature: True)
+    monkeypatch.setattr(twoway, "_health_feature_ok", lambda _health, _feature: True)
+    monkeypatch.setattr(twoway, "_resolve_flags", lambda _fcfg, _sync: {"allow_adds": allow_adds, "allow_removals": allow_removals})
+    monkeypatch.setattr(twoway, "_anime_pair_feature_options", lambda *_args, **_kwargs: {"use_anime_mapping": False})
+    monkeypatch.setattr(twoway, "_anime_config_with_pair_feature_options", lambda cfg, _opts: cfg)
+    monkeypatch.setattr(twoway, "_index_semantics", lambda *_args, **_kwargs: "full")
+    monkeypatch.setattr(twoway, "prev_checkpoint", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(twoway, "module_checkpoint", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(twoway, "keys_for_feature", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(twoway, "_manual_policy", lambda *_args, **_kwargs: ([], set()))
+    monkeypatch.setattr(twoway, "_provider_ignore_dropped_enabled", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(twoway, "apply_blocklist", lambda _state, items, **_kwargs: list(items))
+    monkeypatch.setattr(twoway, "_maybe_block_massdelete", lambda items, **_kwargs: list(items))
+    monkeypatch.setattr(twoway, "effective_chunk_size", lambda *_args, **_kwargs: 100)
+    monkeypatch.setattr(twoway, "load_blackbox_keys", lambda *_args, **_kwargs: set())
+    monkeypatch.setattr(twoway, "record_attempts", lambda *_args, **_kwargs: {"ok": True, "count": 0})
+    monkeypatch.setattr(twoway, "record_success", lambda *_args, **_kwargs: {"ok": True, "count": 0})
+
+
+def _run_two_way(
+    monkeypatch,
+    *,
+    feature: str,
+    a_snap: dict[str, dict[str, Any]],
+    b_snap: dict[str, dict[str, Any]],
+    a_name: str = "PLEX",
+    b_name: str = "SIMKL",
+    prev_state: dict[str, Any] | None = None,
+    allow_adds: bool = True,
+    allow_removals: bool = True,
+    a_ops: _Ops | None = None,
+    b_ops: _Ops | None = None,
+    health_status: dict[str, str] | None = None,
+    fcfg: dict[str, Any] | None = None,
+    verify_after_write: bool = False,
+):
+    _install_common_monkeypatches(monkeypatch, allow_adds=allow_adds, allow_removals=allow_removals)
+    status_by_provider = health_status or {}
+    monkeypatch.setattr(
+        twoway, "_health_status", lambda h: status_by_provider.get((h or {}).get("_name", ""), "up")
+    )
+    aops = a_ops or _Ops()
+    bops = b_ops or _Ops()
+    monkeypatch.setattr(twoway, "build_snapshots_for_feature", lambda **_kwargs: {a_name: a_snap, b_name: b_snap})
+    ctx = SimpleNamespace(
+        config={
+            "sync": {
+                "include_observed_deletes": False,
+                "blackbox": {"enabled": False},
+                "verify_after_write": verify_after_write,
+            },
+            "runtime": {},
+        },
+        providers={a_name: aops, b_name: bops},
+        emit=lambda *_args, **_kwargs: None,
+        emit_info=lambda *_args, **_kwargs: None,
+        dbg=lambda *_args, **_kwargs: None,
+        dry_run=False,
+        snap_cache={},
+        snap_ttl_sec=0,
+        state_store=_StateStore(prev_state),
+        stats_manual_blocked=0,
+        apply_chunk_pause_ms=0,
+    )
+    health_map = {a_name: {"_name": a_name}, b_name: {"_name": b_name}}
+    result = twoway._two_way_sync(ctx, a_name, b_name, feature=feature, fcfg=(fcfg or {}), health_map=health_map)
+    return result, aops, bops, ctx
+
+
+ITEM_700 = {"type": "movie", "title": "Movie700", "year": 2020, "ids": {"tmdb": "700"}, "watched_at": "2024-01-01T00:00:00Z"}
+ITEM_800 = {"type": "movie", "title": "Movie800", "year": 2020, "ids": {"tmdb": "800"}, "watched_at": "2024-01-01T00:00:00Z"}
+
+
+def _prev_state_with(a_name: str, b_name: str, a_items: dict[str, Any], b_items: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "providers": {
+            a_name: {"history": {"baseline": {"items": a_items}}},
+            b_name: {"history": {"baseline": {"items": b_items}}},
+        }
+    }
+
+
+# --- apply-remove: both sides -------------------------------------------------------
+
+
+def test_apply_remove_both_sides_pops_effective_index_and_marks_tombstones(monkeypatch):
+    # 800 was known to SIMKL before, now gone from SIMKL but still on PLEX -> remove from PLEX (A).
+    # 700 was known to PLEX before, now gone from PLEX but still on SIMKL -> remove from SIMKL (B).
+    prev_state = _prev_state_with("PLEX", "SIMKL", {"tmdb:700": ITEM_700}, {"tmdb:800": ITEM_800})
+    result, aops, bops, ctx = _run_two_way(
+        monkeypatch,
+        feature="history",
+        a_snap={"tmdb:800": ITEM_800},
+        b_snap={"tmdb:700": ITEM_700},
+        prev_state=prev_state,
+        allow_adds=True,
+        allow_removals=True,
+    )
+
+    assert result["rem_from_A"] == 1
+    assert result["rem_from_B"] == 1
+    assert aops.removed and canonical_key(aops.removed[0]) == "tmdb:800"
+    assert bops.removed and canonical_key(bops.removed[0]) == "tmdb:700"
+    assert aops.added == [] and bops.added == []
+
+    tomb_keys = ctx.state_store.tomb.get("keys", {})
+    assert any("tmdb:800" in k for k in tomb_keys)
+    assert any("tmdb:700" in k for k in tomb_keys)
+
+
+def test_apply_remove_provider_down_skips_and_records_unresolved(monkeypatch):
+    prev_state = _prev_state_with("PLEX", "SIMKL", {}, {"tmdb:800": ITEM_800})
+    recorded: list[tuple[str, str, list, str]] = []
+    monkeypatch.setattr(
+        twoway, "record_unresolved",
+        lambda provider, feature, items, hint=None: recorded.append((provider, feature, list(items), hint)),
+    )
+    result, aops, bops, ctx = _run_two_way(
+        monkeypatch,
+        feature="history",
+        a_snap={"tmdb:800": ITEM_800},
+        b_snap={},
+        prev_state=prev_state,
+        allow_adds=True,
+        allow_removals=True,
+        health_status={"PLEX": "down"},
+    )
+
+    assert result["rem_from_A"] == 0
+    assert aops.removed == []
+    assert any(r[0] == "PLEX" and r[3] == "provider_down:remove" for r in recorded)
+
+
+# --- apply-update: both sides (ratings, previously zero direct coverage) -----------
+
+
+def test_apply_update_both_sides_when_ratings_differ(monkeypatch):
+    # tmdb:500: PLEX rating newer/higher -> wins -> propagates to SIMKL as an update
+    #   (SIMKL already has this key, so it's reclassified from add to update).
+    # tmdb:600: SIMKL rating newer -> wins -> propagates to PLEX as an update.
+    a_snap = {
+        "tmdb:500": {"type": "movie", "title": "X", "year": 2020, "ids": {"tmdb": "500"},
+                     "rating": 8, "rated_at": "2024-01-02T00:00:00Z"},
+        "tmdb:600": {"type": "movie", "title": "Y", "year": 2021, "ids": {"tmdb": "600"},
+                     "rating": 3, "rated_at": "2024-01-01T00:00:00Z"},
+    }
+    b_snap = {
+        "tmdb:500": {"type": "movie", "title": "X", "year": 2020, "ids": {"tmdb": "500"},
+                     "rating": 5, "rated_at": "2024-01-01T00:00:00Z"},
+        "tmdb:600": {"type": "movie", "title": "Y", "year": 2021, "ids": {"tmdb": "600"},
+                     "rating": 9, "rated_at": "2024-01-02T00:00:00Z"},
+    }
+    result, aops, bops, ctx = _run_two_way(
+        monkeypatch, feature="ratings", a_snap=a_snap, b_snap=b_snap,
+        allow_adds=True, allow_removals=False,
+    )
+
+    assert result["upd_to_A"] == 1
+    assert result["upd_to_B"] == 1
+    # apply_update routes through dst_ops.add, not a separate update method (see
+    # cw_platform/orchestrator/_applier.py - updates are upserts); confirmed by
+    # tests/test_applier_ops.py::test_apply_update_also_calls_dst_ops_add. So the
+    # update payloads land in .added, not .updated, on this fake.
+    assert bops.updated == [] and aops.updated == []
+    assert bops.added and canonical_key(bops.added[0]) == "tmdb:500" and bops.added[0]["rating"] == 8
+    assert aops.added and canonical_key(aops.added[0]) == "tmdb:600" and aops.added[0]["rating"] == 9
+
+
+def test_apply_update_provider_down_skips_and_records_unresolved(monkeypatch):
+    a_snap = {
+        "tmdb:500": {"type": "movie", "title": "X", "year": 2020, "ids": {"tmdb": "500"},
+                     "rating": 8, "rated_at": "2024-01-02T00:00:00Z"},
+    }
+    b_snap = {
+        "tmdb:500": {"type": "movie", "title": "X", "year": 2020, "ids": {"tmdb": "500"},
+                     "rating": 5, "rated_at": "2024-01-01T00:00:00Z"},
+    }
+    recorded: list[tuple[str, str, list, str]] = []
+    monkeypatch.setattr(
+        twoway, "record_unresolved",
+        lambda provider, feature, items, hint=None: recorded.append((provider, feature, list(items), hint)),
+    )
+    result, aops, bops, ctx = _run_two_way(
+        monkeypatch, feature="ratings", a_snap=a_snap, b_snap=b_snap,
+        allow_adds=True, allow_removals=False, health_status={"SIMKL": "down"},
+    )
+
+    assert result["upd_to_B"] == 0
+    assert bops.updated == []
+    assert any(r[0] == "SIMKL" and r[3] == "provider_down:update" for r in recorded)
+    assert result["unresolved_to_B"] == 1
+
+
+# --- apply-add: have_exact_keys / ambiguous_partial / verify_after_write -----------
+
+
+NEW_ITEM = {"type": "movie", "title": "Fresh", "year": 2022, "ids": {"tmdb": "900"}, "watched_at": "2024-01-01T00:00:00Z"}
+
+
+def test_apply_add_with_confirmed_keys_uses_provider_reported_keys(monkeypatch):
+    result, aops, bops, ctx = _run_two_way(
+        monkeypatch, feature="history", a_snap={"tmdb:900": NEW_ITEM}, b_snap={},
+        allow_adds=True, allow_removals=False,
+    )
+    assert result["adds_to_B"] == 1
+    assert bops.added and canonical_key(bops.added[0]) == "tmdb:900"
+
+
+def test_apply_add_without_confirmed_keys_falls_back_to_count_based_reconciliation(monkeypatch):
+    b_ops = _Ops(add_fn=lambda items: {"ok": True, "count": len(items)})  # no confirmed_keys
+    result, aops, bops, ctx = _run_two_way(
+        monkeypatch, feature="history", a_snap={"tmdb:900": NEW_ITEM}, b_snap={},
+        allow_adds=True, allow_removals=False, b_ops=b_ops,
+    )
+    assert result["adds_to_B"] == 1
+    assert bops.added and canonical_key(bops.added[0]) == "tmdb:900"
+
+
+def test_apply_add_ambiguous_partial_when_provider_reports_skipped_without_exact_keys(monkeypatch):
+    # Two items attempted, provider reports only 1 confirmed plus skipped=True, but
+    # WITHOUT confirmed_keys telling us which one succeeded. With 2 candidates and a
+    # provider-confirmed count of 1, we can't tell which item actually landed, so the
+    # ambiguous_partial guard conservatively reports 0 effective adds rather than
+    # guessing (see _pairs_twoway.py's `ambiguous_partial_B` computation).
+    other_item = {"type": "movie", "title": "Fresh2", "year": 2022, "ids": {"tmdb": "901"}, "watched_at": "2024-01-01T00:00:00Z"}
+    b_ops = _Ops(add_fn=lambda items: {"ok": True, "count": 1, "skipped": True})
+    result, aops, bops, ctx = _run_two_way(
+        monkeypatch, feature="history",
+        a_snap={"tmdb:900": NEW_ITEM, "tmdb:901": other_item}, b_snap={},
+        allow_adds=True, allow_removals=False, b_ops=b_ops,
+    )
+    assert result["adds_to_B"] == 0
+    assert result["resB_add"]["skipped"] == 1
+
+
+def test_apply_add_verify_after_write_filters_keys_still_unresolved(monkeypatch):
+    # Provider confirms the add server-side (confirmed_keys present -> have_exact_keys),
+    # but a post-write re-check of unresolved-keys shows it's still unresolved, so
+    # verify_after_write must exclude it from the effective/success count even though
+    # the item was genuinely sent to the provider.
+    monkeypatch.setattr(twoway, "_apply_verify_after_write_supported", lambda _ops: True)
+    calls = {"n": 0}
+
+    def _load_unresolved(provider, feature, cross_features=False):
+        # 1st call = unresolved_before (empty); 2nd call = unresolved_after (empty);
+        # 3rd call = the verify-after-write re-check, which reports it unresolved.
+        calls["n"] += 1
+        return {"tmdb:900"} if calls["n"] >= 3 else set()
+
+    monkeypatch.setattr(twoway, "load_unresolved_keys", _load_unresolved)
+    b_ops = _Ops()
+    result, aops, bops, ctx = _run_two_way(
+        monkeypatch, feature="history", a_snap={"tmdb:900": NEW_ITEM}, b_snap={},
+        allow_adds=True, allow_removals=False, b_ops=b_ops, verify_after_write=True,
+    )
+
+    assert result["adds_to_B"] == 0
+    assert bops.added and canonical_key(bops.added[0]) == "tmdb:900"
+
+
+def test_apply_add_provider_down_skips_and_records_unresolved(monkeypatch):
+    recorded: list[tuple[str, str, list, str]] = []
+    monkeypatch.setattr(
+        twoway, "record_unresolved",
+        lambda provider, feature, items, hint=None: recorded.append((provider, feature, list(items), hint)),
+    )
+    result, aops, bops, ctx = _run_two_way(
+        monkeypatch, feature="history", a_snap={"tmdb:900": NEW_ITEM}, b_snap={},
+        allow_adds=True, allow_removals=False, health_status={"SIMKL": "down"},
+    )
+    assert result["adds_to_B"] == 0
+    assert bops.added == []
+    assert any(r[0] == "SIMKL" and r[3] == "provider_down:add" for r in recorded)
+    assert result["unresolved_to_B"] == 1


### PR DESCRIPTION
## Summary

Continues the simplification effort from #56/#57/#58. `_two_way_sync` in
`cw_platform/orchestrator/_pairs_twoway.py` had its apply-remove/update/add logic
copy-pasted once per side (A and B) — confirmed via a name-normalized diff that the
two copies differ **only** in identifiers (`a`/`b`, `aops`/`bops`, `A_eff`/`B_eff`,
`resA_*`/`resB_*`, etc.), not behavior. This was the single biggest duplication
target left in the orchestrator per a structural scan of both `_pairs_oneway.py` and
`_pairs_twoway.py`.

This is real sync-engine logic (add/remove/update propagation between two media
providers), so — per discussion before starting — this got the highest scrutiny of
any tier so far: test-first, with new coverage for paths that had **zero** direct
test coverage before touching anything.

## What changed

**Commit 1** (`b7dc865`) — `tests/test_twoway_apply_sides.py`, 9 new tests, run and
confirmed green against the *original* duplicated code before any refactor:
- apply-remove for both sides (pops the effective index, marks tombstones)
- apply-update for both sides — **previously never exercised at all** — driven
  through the real ratings rating-conflict-resolution diff logic (differing
  `rated_at`/`rating` values on each side, reclassified from add to update because
  the target already has the key)
- provider-down handling for remove/update/add (skips apply, records unresolved)
- apply-add's `have_exact_keys` true/false paths, the `ambiguous_partial` guard
  (provider reports a partial success without telling us which item — conservatively
  reports 0 rather than guessing), and `verify_after_write` filtering out keys a
  post-write recheck still reports unresolved

**Commit 2** (`d73fbbf`) — extracted `_apply_remove_side`, `_apply_update_side`,
`_apply_add_side` as closures nested *inside* `_two_way_sync` (not module-level, not
moved to another file). That's deliberate: `test_twoway_history_specials.py`
monkeypatches ~18 names at the `_pairs_twoway` module level and calls `_two_way_sync`
directly — moving this logic elsewhere would've silently broken those monkeypatches.
Staying nested means the helpers still close over `feature`, `provider_cfg`,
`emit`/`dbg`, `ctx`, `pair_key`, `verify_after_write`, `_mark_tombs`,
`_bust_snapshot`, etc. exactly as the inline blocks did — only the genuinely
per-side values (ops, name, down-flag, items, effective index, guard) become
parameters.

Each side's call site is now one line, e.g.:
```python
resA_add, eff_add_A, new_unres = _apply_add_side("A", aops, a, a_down, add_to_A, A_eff, guardA)
resB_add, eff_add_B, new_unres = _apply_add_side("B", bops, b, b_down, add_to_B, B_eff, guardB)
```
instead of two ~115-line inline blocks.

## Verification

- All 9 new tests plus the existing `test_twoway_history_specials.py` pass
  identically before and after the refactor.
- Net **-148 lines** in `_pairs_twoway.py`.
- Full suite passes with the same 3 pre-existing unrelated failures present on
  `main` (`test_dashboard_widgets`, `test_meta_api_episode_stills`,
  `test_playback_progress`).

`_pairs_oneway.py` (one-way sync) is untouched — it has no A/B duplication to
collapse (it's one-directional), so a from-scratch split there would just be
readability polish, not deduplication; left out of this PR's scope.