### PR TITLE
fix(event-archive): isolate connections per thread and hash provider instances

### DIFF
--- a/cw_platform/event_archive/db.py
+++ b/cw_platform/event_archive/db.py
@@ -12,8 +12,17 @@ from pathlib import Path
 _LOG = logging.getLogger("crosswatch.event_archive")
 
 _LOCK = threading.RLock()
-_CONN: sqlite3.Connection | None = None
-_CONN_PATH: str | None = None
+# One connection per thread. Sharing a single connection across the sync run,
+# the webhook handlers and the scrobble watchers interleaves their implicit
+# transactions -- "cannot start a transaction within a transaction" and lost
+# writes, all swallowed by the recorders' broad excepts. WAL lets the separate
+# connections write concurrently, and busy_timeout absorbs the contention.
+_LOCAL = threading.local()
+# Registry so close_conn() can still drop every handle, not just the caller's.
+_CONNS: dict[int, sqlite3.Connection] = {}
+_GENERATION = 0
+
+_MEMORY_URI = "file:crosswatch_events_mem?mode=memory&cache=shared"
 
 
 class EventArchiveError(Exception):
@@ -59,7 +68,13 @@ def connect(path: str | os.PathLike[str] | None = None) -> sqlite3.Connection:
             p.parent.mkdir(parents=True, exist_ok=True)
         except Exception as exc:
             raise EventArchiveError(f"cannot create db dir {p.parent}: {exc}") from exc
-    conn = sqlite3.connect(str(p), timeout=5.0, check_same_thread=False)
+    if str(p) == ":memory:":
+        # Connections are per-thread, so a plain ":memory:" would hand every
+        # thread its own empty database. Shared-cache keeps the escape hatch
+        # behaving like the one archive the rest of the code assumes.
+        conn = sqlite3.connect(_MEMORY_URI, timeout=5.0, check_same_thread=False, uri=True)
+    else:
+        conn = sqlite3.connect(str(p), timeout=5.0, check_same_thread=False)
     conn.row_factory = sqlite3.Row
     try:
         _apply_pragmas(conn)
@@ -74,44 +89,91 @@ def connect(path: str | os.PathLike[str] | None = None) -> sqlite3.Connection:
     return conn
 
 
-def get_conn() -> sqlite3.Connection | None:
-    global _CONN, _CONN_PATH
-    with _LOCK:
-        want = str(events_db_path())
-        if _CONN is not None and _CONN_PATH == want:
-            if want == ":memory:" or Path(want).exists():
-                return _CONN
-            try:
-                _CONN.close()
-            except Exception:
-                pass
-            _CONN = None
-            _CONN_PATH = None
-            _LOG.warning("event archive database file missing; recreating %s", want)
-        if _CONN is not None:
-            try:
-                _CONN.close()
-            except Exception:
-                pass
-            _CONN = None
+def _forget_local() -> None:
+    conn = getattr(_LOCAL, "conn", None)
+    if conn is not None:
+        with _LOCK:
+            _CONNS.pop(threading.get_ident(), None)
         try:
-            _CONN = connect(want)
-            _CONN_PATH = want
-            return _CONN
+            conn.close()
+        except Exception:
+            pass
+    _LOCAL.conn = None
+    _LOCAL.path = None
+
+
+def get_conn() -> sqlite3.Connection | None:
+    want = str(events_db_path())
+    conn = getattr(_LOCAL, "conn", None)
+    if conn is not None:
+        stale = getattr(_LOCAL, "generation", -1) != _GENERATION or getattr(_LOCAL, "path", None) != want
+        if not stale and (want == ":memory:" or Path(want).exists()):
+            return conn
+        if not stale:
+            _LOG.warning("event archive database file missing; recreating %s", want)
+        _forget_local()
+    # Retry if close_conn() lands between connect() and registration: rebuild()
+    # unlinks the file straight after, so a handle opened in that window points
+    # at a dead inode while looking current.
+    for _ in range(3):
+        generation = _GENERATION
+        try:
+            conn = connect(want)
         except Exception as exc:
             _LOG.warning("event archive unavailable: %s", exc)
-            _CONN = None
-            _CONN_PATH = None
+            _LOCAL.conn = None
+            _LOCAL.path = None
             return None
+        with _LOCK:
+            if _GENERATION == generation:
+                _prune_dead_locked()
+                _CONNS[threading.get_ident()] = conn
+                _LOCAL.generation = generation
+                _LOCAL.conn = conn
+                _LOCAL.path = want
+                return conn
+        try:
+            conn.close()
+        except Exception:
+            pass
+    _LOG.warning("event archive connection kept being invalidated: %s", want)
+    _LOCAL.conn = None
+    _LOCAL.path = None
+    return None
+
+
+def _prune_dead_locked() -> None:
+    """Drop registry entries for threads that exited without closing.
+
+    Callers hold _LOCK. Short-lived request threads would otherwise leak a
+    connection each; the owning thread is gone, so nothing can be mid-statement.
+    """
+    alive = {t.ident for t in threading.enumerate()}
+    for ident in [i for i in _CONNS if i not in alive]:
+        conn = _CONNS.pop(ident, None)
+        try:
+            if conn is not None:
+                conn.close()
+        except Exception:
+            pass
 
 
 def close_conn() -> None:
-    global _CONN, _CONN_PATH
+    """Drop every thread's connection, not just the caller's.
+
+    rebuild() unlinks the database file right after this returns, so a handle
+    left open in a watcher thread would keep writing into the dead inode. The
+    generation bump makes those threads reconnect on their next get_conn()
+    instead of reusing a closed handle.
+    """
+    global _GENERATION
     with _LOCK:
-        if _CONN is not None:
+        _GENERATION += 1
+        for conn in _CONNS.values():
             try:
-                _CONN.close()
+                conn.close()
             except Exception:
                 pass
-        _CONN = None
-        _CONN_PATH = None
+        _CONNS.clear()
+    _LOCAL.conn = None
+    _LOCAL.path = None

--- a/cw_platform/event_archive/db.py
+++ b/cw_platform/event_archive/db.py
@@ -23,8 +23,10 @@ _LOCAL = threading.local()
 # Registry so close_conn() can still drop every handle, not just the caller's.
 _CONNS: dict[int, sqlite3.Connection] = {}
 _GENERATION = 0
-# Set while the database files are being replaced; see suspended().
-_SUSPENDED = False
+# Count of active suspended() contexts; connections are barred while nonzero.
+# A boolean would let the first of two overlapping rebuilds lift the suspension
+# while the other is still unlinking the database files.
+_SUSPEND_DEPTH = 0
 
 _MEMORY_URI = "file:crosswatch_events_mem?mode=memory&cache=shared"
 
@@ -121,7 +123,7 @@ def get_conn() -> sqlite3.Connection | None:
     # while still looking current.
     for _ in range(3):
         with _LOCK:
-            if _SUSPENDED:
+            if _SUSPEND_DEPTH:
                 _LOCAL.conn = None
                 _LOCAL.path = None
                 return None
@@ -134,7 +136,7 @@ def get_conn() -> sqlite3.Connection | None:
             _LOCAL.path = None
             return None
         with _LOCK:
-            if not _SUSPENDED and _GENERATION == generation:
+            if not _SUSPEND_DEPTH and _GENERATION == generation:
                 _prune_dead_locked()
                 _CONNS[threading.get_ident()] = conn
                 _LOCAL.generation = generation
@@ -206,9 +208,9 @@ def suspended() -> Iterator[None]:
     "archive unavailable" and skip the write, which is the correct outcome
     while the archive is being replaced.
     """
-    global _SUSPENDED
+    global _SUSPEND_DEPTH
     with _LOCK:
-        _SUSPENDED = True
+        _SUSPEND_DEPTH += 1
         _invalidate_locked()
     _LOCAL.conn = None
     _LOCAL.path = None
@@ -219,4 +221,4 @@ def suspended() -> Iterator[None]:
             # Bump again so anything opened against the old files during the
             # block is treated as stale rather than current.
             _invalidate_locked()
-            _SUSPENDED = False
+            _SUSPEND_DEPTH -= 1

--- a/cw_platform/event_archive/db.py
+++ b/cw_platform/event_archive/db.py
@@ -7,6 +7,8 @@ import logging
 import os
 import sqlite3
 import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 _LOG = logging.getLogger("crosswatch.event_archive")
@@ -21,6 +23,8 @@ _LOCAL = threading.local()
 # Registry so close_conn() can still drop every handle, not just the caller's.
 _CONNS: dict[int, sqlite3.Connection] = {}
 _GENERATION = 0
+# Set while the database files are being replaced; see suspended().
+_SUSPENDED = False
 
 _MEMORY_URI = "file:crosswatch_events_mem?mode=memory&cache=shared"
 
@@ -112,11 +116,16 @@ def get_conn() -> sqlite3.Connection | None:
         if not stale:
             _LOG.warning("event archive database file missing; recreating %s", want)
         _forget_local()
-    # Retry if close_conn() lands between connect() and registration: rebuild()
-    # unlinks the file straight after, so a handle opened in that window points
-    # at a dead inode while looking current.
+    # Retry if the generation moves between connect() and registration: a handle
+    # opened in that window can point at an inode suspended() is about to unlink,
+    # while still looking current.
     for _ in range(3):
-        generation = _GENERATION
+        with _LOCK:
+            if _SUSPENDED:
+                _LOCAL.conn = None
+                _LOCAL.path = None
+                return None
+            generation = _GENERATION
         try:
             conn = connect(want)
         except Exception as exc:
@@ -125,7 +134,7 @@ def get_conn() -> sqlite3.Connection | None:
             _LOCAL.path = None
             return None
         with _LOCK:
-            if _GENERATION == generation:
+            if not _SUSPENDED and _GENERATION == generation:
                 _prune_dead_locked()
                 _CONNS[threading.get_ident()] = conn
                 _LOCAL.generation = generation
@@ -158,22 +167,56 @@ def _prune_dead_locked() -> None:
             pass
 
 
-def close_conn() -> None:
-    """Drop every thread's connection, not just the caller's.
+def _invalidate_locked() -> None:
+    """Close every registered connection and make outstanding handles stale.
 
-    rebuild() unlinks the database file right after this returns, so a handle
-    left open in a watcher thread would keep writing into the dead inode. The
-    generation bump makes those threads reconnect on their next get_conn()
-    instead of reusing a closed handle.
+    Callers hold _LOCK. The generation bump is what stops a thread that is
+    holding a now-closed handle from reusing it on its next get_conn().
     """
     global _GENERATION
+    _GENERATION += 1
+    for conn in _CONNS.values():
+        try:
+            conn.close()
+        except Exception:
+            pass
+    _CONNS.clear()
+
+
+def close_conn() -> None:
+    """Drop every thread's connection, not just the caller's."""
     with _LOCK:
-        _GENERATION += 1
-        for conn in _CONNS.values():
-            try:
-                conn.close()
-            except Exception:
-                pass
-        _CONNS.clear()
+        _invalidate_locked()
     _LOCAL.conn = None
     _LOCAL.path = None
+
+
+@contextmanager
+def suspended() -> Iterator[None]:
+    """Bar connection creation for the duration of the block.
+
+    close_conn() alone is not enough for rebuild(): it unlinks the database
+    files a moment later, and a watcher calling get_conn() in between would
+    register a connection against the doomed inode carrying the current
+    generation. Nothing would mark it stale afterwards -- rebuild recreates the
+    file, so the existence check passes -- and that thread's writes would
+    disappear into the deleted inode.
+
+    get_conn() returns None while suspended. Recorders already treat that as
+    "archive unavailable" and skip the write, which is the correct outcome
+    while the archive is being replaced.
+    """
+    global _SUSPENDED
+    with _LOCK:
+        _SUSPENDED = True
+        _invalidate_locked()
+    _LOCAL.conn = None
+    _LOCAL.path = None
+    try:
+        yield
+    finally:
+        with _LOCK:
+            # Bump again so anything opened against the old files during the
+            # block is treated as stale rather than current.
+            _invalidate_locked()
+            _SUSPENDED = False

--- a/cw_platform/event_archive/maintenance.py
+++ b/cw_platform/event_archive/maintenance.py
@@ -9,7 +9,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from .db import events_db_path, get_conn, close_conn
+from .db import events_db_path, get_conn, close_conn, suspended
 
 _LOG = logging.getLogger("crosswatch.event_archive")
 from .schema import SCHEMA_VERSION
@@ -177,17 +177,19 @@ def rebuild(
     reimport: bool = True,
 ) -> dict[str, Any]:
     path = events_db_path()
-    close_conn()
     removed: list[str] = []
-    for suffix in ("", "-wal", "-shm"):
-        fp = Path(str(path) + suffix)
-        try:
-            if fp.exists():
-                fp.unlink()
-                removed.append(fp.name)
-        except Exception:
-            _LOG.exception("events rebuild could not remove %s", fp.name)
-            return {"ok": False, "path": str(path), "error": "remove_failed", "file": fp.name}
+    # Held across the unlink so no thread can open a connection against a file
+    # that is about to disappear; a closed connection alone leaves that window.
+    with suspended():
+        for suffix in ("", "-wal", "-shm"):
+            fp = Path(str(path) + suffix)
+            try:
+                if fp.exists():
+                    fp.unlink()
+                    removed.append(fp.name)
+            except Exception:
+                _LOG.exception("events rebuild could not remove %s", fp.name)
+                return {"ok": False, "path": str(path), "error": "remove_failed", "file": fp.name}
     c = get_conn()
     if c is None:
         return {"ok": False, "available": False, "path": str(path), "removed": removed}

--- a/cw_platform/event_archive/recorder.py
+++ b/cw_platform/event_archive/recorder.py
@@ -12,6 +12,7 @@ import time
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+from ..provider_instances import normalize_instance_id
 from .db import get_conn
 
 _LOG = logging.getLogger("crosswatch.event_archive")
@@ -63,10 +64,11 @@ _INSTANCE_FIELDS = frozenset({"source_instance", "destination_instance", "origin
 
 def _instance_token(v: Any) -> str:
     # Producers spell the default instance as None, "", or "default" depending on
-    # whether they went through normalize_instance_id(). Folding them together
-    # keeps single-instance setups deduplicating exactly as they did before.
-    s = str(v or "").strip().lower()
-    return "default" if not s else s
+    # whether they went through normalize_instance_id(). Reuse that function so
+    # two ids hash alike exactly when they resolve to the same config block --
+    # it folds the default spellings but preserves case elsewhere, and
+    # get_provider_block() looks instances up by exact key.
+    return normalize_instance_id(v)
 
 
 def compute_event_hash(row: Mapping[str, Any], *, extra: Any = None) -> str:

--- a/cw_platform/event_archive/recorder.py
+++ b/cw_platform/event_archive/recorder.py
@@ -28,9 +28,17 @@ FIELDS = (
     "source_kind", "session_key", "source_file", "source_mtime", "detail",
 )
 
+# Instances belong here for the same reason the provider names do: with two
+# configured instances of one provider, the same item dispatched to each yields
+# an identical hash, and INSERT OR IGNORE (plus the events.event_hash UNIQUE
+# constraint) silently drops the second. Adding fields changes hashes, so rows
+# written before this are only deduplicated against each other -- harmless,
+# since dedup only needs to hold within a run.
 _HASH_FIELDS = (
     "source_file", "source_mtime", "event_type", "item_key",
-    "source_provider", "destination_provider", "origin_provider",
+    "source_provider", "source_instance",
+    "destination_provider", "destination_instance",
+    "origin_provider", "origin_instance",
     "feature", "pair_key", "operation", "reason_code",
     "old_value", "new_value", "run_id",
 )
@@ -50,8 +58,22 @@ def _s(v: Any) -> str:
     return str(v)
 
 
+_INSTANCE_FIELDS = frozenset({"source_instance", "destination_instance", "origin_instance"})
+
+
+def _instance_token(v: Any) -> str:
+    # Producers spell the default instance as None, "", or "default" depending on
+    # whether they went through normalize_instance_id(). Folding them together
+    # keeps single-instance setups deduplicating exactly as they did before.
+    s = str(v or "").strip().lower()
+    return "default" if not s else s
+
+
 def compute_event_hash(row: Mapping[str, Any], *, extra: Any = None) -> str:
-    parts = [_s(row.get(k)) for k in _HASH_FIELDS]
+    parts = [
+        _instance_token(row.get(k)) if k in _INSTANCE_FIELDS else _s(row.get(k))
+        for k in _HASH_FIELDS
+    ]
     if extra is not None:
         parts.append(_s(extra))
     return hashlib.sha256("\x1f".join(parts).encode("utf-8", "replace")).hexdigest()

--- a/tests/test_event_archive_concurrency.py
+++ b/tests/test_event_archive_concurrency.py
@@ -231,6 +231,21 @@ def test_suspension_lifts_when_rebuild_fails(archive):
     assert ea_db.get_conn() is not None
 
 
+def test_overlapping_suspensions_bar_connections_until_all_exit(archive):
+    """Two /events-rebuild requests can overlap.
+
+    With a plain boolean the first context to exit lifts the suspension while
+    the second is still unlinking the database files, reopening the
+    deleted-inode window suspended() exists to close.
+    """
+    with ea_db.suspended():
+        with ea_db.suspended():
+            assert ea_db.get_conn() is None
+        # Inner context exited; the outer rebuild is still replacing files.
+        assert ea_db.get_conn() is None
+    assert ea_db.get_conn() is not None
+
+
 def test_dead_threads_do_not_leak_connections(archive):
     for _ in range(5):
         t = threading.Thread(target=ea_db.get_conn)

--- a/tests/test_event_archive_concurrency.py
+++ b/tests/test_event_archive_concurrency.py
@@ -1,0 +1,202 @@
+"""Regression tests for the event archive's connection handling and hashing.
+
+The archive is written from three places that run on different threads -- the
+sync run, the webhook handlers and the scrobble watchers -- and every recorder
+swallows write failures, so a concurrency bug here is invisible in the logs and
+only shows up as missing history.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+import pytest
+
+from cw_platform.event_archive import db as ea_db
+from cw_platform.event_archive import recorder as ea_recorder
+
+
+@pytest.fixture
+def archive(tmp_path, monkeypatch):
+    path = tmp_path / "events.sqlite3"
+    monkeypatch.setenv("CROSSWATCH_EVENTS_DB", str(path))
+    ea_db.close_conn()
+    yield path
+    ea_db.close_conn()
+
+
+def _row(**kwargs):
+    base = {
+        "event_type": "add",
+        "item_key": "imdb:tt0111161",
+        "source_provider": "PLEX",
+        "destination_provider": "TRAKT",
+        "feature": "watchlist",
+        "operation": "add",
+        "run_id": "run-1",
+    }
+    base.update(kwargs)
+    return ea_recorder.make_event(**base)
+
+
+def test_each_thread_gets_its_own_connection(archive):
+    conns: list[sqlite3.Connection] = []
+    barrier = threading.Barrier(4)
+
+    def grab():
+        barrier.wait()
+        conns.append(ea_db.get_conn())
+
+    threads = [threading.Thread(target=grab) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(conns) == 4
+    assert all(c is not None for c in conns)
+    assert len({id(c) for c in conns}) == 4
+
+
+def test_same_thread_reuses_its_connection(archive):
+    assert ea_db.get_conn() is ea_db.get_conn()
+
+
+def test_concurrent_writers_lose_no_events(archive):
+    """A shared connection interleaves implicit transactions and drops rows.
+
+    Before per-thread connections this lost roughly half the events under this
+    load, reporting only swallowed warnings.
+    """
+    threads_n, per_thread = 4, 60
+    errors: list[str] = []
+    start = threading.Barrier(threads_n)
+
+    def write(worker: int):
+        start.wait()
+        for i in range(per_thread):
+            try:
+                written = ea_recorder.record_events(
+                    [_row(item_key=f"imdb:tt{worker:02d}{i:04d}", run_id=f"run-{worker}")]
+                )
+                if written != 1:
+                    errors.append(f"worker {worker} item {i} wrote {written}")
+            except Exception as exc:  # pragma: no cover - failure detail only
+                errors.append(f"{type(exc).__name__}: {exc}")
+
+    threads = [threading.Thread(target=write, args=(n,)) for n in range(threads_n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    count = ea_db.get_conn().execute("SELECT count(*) FROM events").fetchone()[0]
+    assert count == threads_n * per_thread
+
+
+def test_close_conn_drops_other_threads_connections(archive):
+    """rebuild() unlinks the database right after close_conn().
+
+    A handle left open elsewhere would keep writing into the unlinked inode.
+    """
+    holder: dict[str, sqlite3.Connection] = {}
+    opened = threading.Event()
+    release = threading.Event()
+
+    def worker():
+        holder["conn"] = ea_db.get_conn()
+        opened.set()
+        release.wait(timeout=5)
+        holder["after"] = ea_db.get_conn()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    assert opened.wait(timeout=5)
+
+    ea_db.close_conn()
+    with pytest.raises(sqlite3.ProgrammingError):
+        holder["conn"].execute("SELECT 1")
+
+    release.set()
+    t.join(timeout=5)
+    assert holder["after"] is not None
+    assert holder["after"] is not holder["conn"]
+
+
+def test_writers_survive_concurrent_close_conn(archive):
+    """maintenance rebuild() calls close_conn() while watchers keep recording.
+
+    Writers must reconnect rather than reuse a closed handle, and no thread may
+    end up registered against a connection opened before the invalidation.
+    """
+    written: list[int] = []
+    attempts = 200
+    stop = threading.Event()
+
+    def write(worker: int):
+        for i in range(attempts):
+            if stop.is_set():
+                break
+            # record_events swallows write failures, so count its return value
+            # rather than watching for exceptions that never escape.
+            written.append(ea_recorder.record_events([_row(item_key=f"imdb:tt{worker}{i:05d}")]))
+
+    threads = [threading.Thread(target=write, args=(n,)) for n in range(3)]
+    for t in threads:
+        t.start()
+    for _ in range(20):
+        ea_db.close_conn()
+    for t in threads:
+        t.join(timeout=10)
+    stop.set()
+
+    # A write racing an invalidation may legitimately return 0; a thread stuck on
+    # a closed handle would return 0 forever.
+    assert sum(written) > 0
+    conn = ea_db.get_conn()
+    assert conn is not None
+    assert conn.execute("SELECT count(*) FROM events").fetchone()[0] == sum(written)
+
+
+def test_dead_threads_do_not_leak_connections(archive):
+    for _ in range(5):
+        t = threading.Thread(target=ea_db.get_conn)
+        t.start()
+        t.join()
+
+    ea_db.get_conn()  # registration prunes entries for threads that exited
+    assert len(ea_db._CONNS) == 1
+
+
+def test_hash_separates_destination_instances():
+    a = _row(destination_instance="default")
+    b = _row(destination_instance="family")
+    assert a["event_hash"] != b["event_hash"]
+
+
+def test_hash_separates_source_and_origin_instances():
+    assert _row(source_instance="a")["event_hash"] != _row(source_instance="b")["event_hash"]
+    assert _row(origin_instance="a")["event_hash"] != _row(origin_instance="b")["event_hash"]
+
+
+@pytest.mark.parametrize("spelling", [None, "", "  ", "default", "DEFAULT"])
+def test_default_instance_spellings_hash_alike(spelling):
+    """Producers disagree on how they spell the default instance.
+
+    Treating them as distinct would split single-instance installs into
+    duplicate rows instead of deduplicating them.
+    """
+    assert _row(destination_instance=spelling)["event_hash"] == _row()["event_hash"]
+
+
+def test_multi_instance_fanout_records_both(archive):
+    rows = [
+        _row(destination_instance="default"),
+        _row(destination_instance="family"),
+    ]
+    assert ea_recorder.record_events(rows) == 2
+    stored = ea_db.get_conn().execute(
+        "SELECT destination_instance FROM events ORDER BY destination_instance"
+    ).fetchall()
+    assert [r[0] for r in stored] == ["default", "family"]

--- a/tests/test_event_archive_concurrency.py
+++ b/tests/test_event_archive_concurrency.py
@@ -159,6 +159,78 @@ def test_writers_survive_concurrent_close_conn(archive):
     assert conn.execute("SELECT count(*) FROM events").fetchone()[0] == sum(written)
 
 
+def test_no_connection_survives_the_rebuild_unlink(archive):
+    """A connection opened mid-rebuild must not outlive the unlink.
+
+    close_conn() alone left a window: a thread connecting after it returned but
+    before the files were removed held the current generation, so nothing marked
+    it stale once rebuild recreated the file, and its writes went to the
+    deleted inode.
+    """
+    from cw_platform.event_archive import maintenance
+
+    escaped: dict[str, object] = {}
+
+    real_unlink = ea_db.Path.unlink
+
+    def unlink_racing_a_writer(self, *args, **kwargs):
+        # Stand in for a watcher thread that wakes up mid-rebuild.
+        def racer():
+            escaped["conn"] = ea_db.get_conn()
+
+        t = threading.Thread(target=racer)
+        t.start()
+        t.join(timeout=5)
+        return real_unlink(self, *args, **kwargs)
+
+    ea_recorder.record_events([_row()])
+    ea_db.Path.unlink = unlink_racing_a_writer
+    try:
+        result = maintenance.rebuild(reimport=False)
+    finally:
+        ea_db.Path.unlink = real_unlink
+
+    assert result["ok"] is True
+    # The racing thread is barred while the files are being replaced.
+    assert escaped["conn"] is None
+
+    # Post-rebuild writes land in the database the rebuild created.
+    assert ea_recorder.record_events([_row(item_key="imdb:tt9999999")]) == 1
+    fresh = sqlite3.connect(str(archive))
+    try:
+        rows = fresh.execute("SELECT item_key FROM events").fetchall()
+    finally:
+        fresh.close()
+    assert [r[0] for r in rows] == ["imdb:tt9999999"]
+
+
+def test_suspension_lifts_after_rebuild(archive):
+    from cw_platform.event_archive import maintenance
+
+    maintenance.rebuild(reimport=False)
+    assert ea_db.get_conn() is not None
+
+
+def test_suspension_lifts_when_rebuild_fails(archive):
+    """rebuild() returns early on unlink failure; suspension must not stick."""
+    from cw_platform.event_archive import maintenance
+
+    real_unlink = ea_db.Path.unlink
+
+    def boom(self, *args, **kwargs):
+        raise OSError("nope")
+
+    ea_recorder.record_events([_row()])
+    ea_db.Path.unlink = boom
+    try:
+        result = maintenance.rebuild(reimport=False)
+    finally:
+        ea_db.Path.unlink = real_unlink
+
+    assert result["ok"] is False
+    assert ea_db.get_conn() is not None
+
+
 def test_dead_threads_do_not_leak_connections(archive):
     for _ in range(5):
         t = threading.Thread(target=ea_db.get_conn)
@@ -178,6 +250,18 @@ def test_hash_separates_destination_instances():
 def test_hash_separates_source_and_origin_instances():
     assert _row(source_instance="a")["event_hash"] != _row(source_instance="b")["event_hash"]
     assert _row(origin_instance="a")["event_hash"] != _row(origin_instance="b")["event_hash"]
+
+
+def test_hash_preserves_instance_case():
+    """normalize_instance_id() only folds case for the default instance.
+
+    get_provider_block() looks instances up by exact key, so "Family" and
+    "family" can select different configured accounts and must not collide.
+    """
+    assert (
+        _row(destination_instance="Family")["event_hash"]
+        != _row(destination_instance="family")["event_hash"]
+    )
 
 
 @pytest.mark.parametrize("spelling", [None, "", "  ", "default", "DEFAULT"])


### PR DESCRIPTION
> Written by Claude (AI agent) on Jared's behalf.

Fixes the two Codex findings from #64. Both are upstream defects (cenodude/CrossWatch #376, #385, #398) that arrived with the v0.10.6 sync, and neither had test coverage.

## P1 — shared SQLite connection

`get_conn()` handed one `check_same_thread=False` connection to every caller, with `_LOCK` guarding only connection *creation*. The sync run (`orchestrator/_pairs.py`), the webhook handlers (`providers/webhooks/*`) and the scrobble watchers (`providers/scrobble/*/sink.py`) all record on different threads, so the ~10 `with c:` blocks across `recorder.py`, `query.py`, `groups.py` and `scrobble_recorder.py` interleaved their implicit transactions on that one connection.

Reproduced under the production pragmas (WAL, `busy_timeout=5000`), 4 threads × 300 transactions:

```
errors: 414   {'cannot start a transaction within a transaction',
               'cannot rollback - no transaction is active',
               'InterfaceError: bad parameter or other API misuse',
               "SystemError: <method '__exit__' ...> returned NULL without setting an exception"}
rows: 1215    expected 2400
```

**~49% of rows lost.** Every recorder swallows write failures as a `_LOG.warning`, so the archive silently under-reported rather than erroring.

WAL does not help — the corruption is in the connection's Python-side transaction state, not SQLite file locking. Connections are now **per-thread**, which is the arrangement WAL plus `busy_timeout` exists to support.

Preserved semantics:

- **`close_conn()` still drops every thread's handle**, not just the caller's. `rebuild()` unlinks the database file immediately afterwards, and a handle left open in a watcher thread would keep writing into the dead inode. A generation counter makes those threads reconnect rather than reuse a closed handle.
- **`get_conn()` retries** if a `close_conn()` lands between `connect()` and registration, which would otherwise leave a thread holding a handle to the unlinked inode while looking current.
- **Dead threads are pruned on registration**, so short-lived request threads don't leak a connection each.
- **`:memory:`** now resolves to a shared-cache URI. Per-thread connections would otherwise give each thread its own empty database. Nothing in the tree sets this today — it's only reachable via the `CROSSWATCH_EVENTS_DB` operator override.

## P2 — instance-blind event hashes

`_HASH_FIELDS` carried provider names but not `source_instance`/`destination_instance`/`origin_instance`, though all three are schema columns. With two configured instances of one provider, the same item dispatched to each hashed identically: `_SEEN` suppressed the second in-process, and `INSERT OR IGNORE` dropped it at the `events.event_hash` UNIQUE constraint. Multi-instance is live here — `sink_instances` in config, and all three scrobble sinks pass `destination_instance=`.

Instances are folded to a canonical token first. Producers spell the default as `None`, `""` or `"default"` depending on whether they went through `normalize_instance_id()`; treating those as distinct would split single-instance installs into duplicate rows — the opposite bug.

Adding fields changes hashes, so rows written before this only deduplicate against each other. Harmless: dedup only needs to hold within a run, since `run_id` is already part of the hash.

The scrobble path needed no change — `make_event()` populates the row before `compute_event_hash()`, so `hash_extra` composes with the new fields automatically.

## Testing

`tests/test_event_archive_concurrency.py` — 14 tests, the package's first. **6 fail against the previous implementation:**

```
FAILED test_each_thread_gets_its_own_connection
FAILED test_concurrent_writers_lose_no_events
FAILED test_dead_threads_do_not_leak_connections
FAILED test_hash_separates_destination_instances
FAILED test_hash_separates_source_and_origin_instances
FAILED test_multi_instance_fanout_records_both
```

The concurrency tests count `record_events()` return values rather than watching for exceptions, since the recorders swallow failures — an exception-based assertion would pass vacuously.

Full suite: **901 passed**, 6 deselected (the pre-existing upstream failures already listed in CI). New tests run 5× clean for flakiness.