### PR TITLE
fix(ui): stop unbounded event listener and interval accumulation

### DIFF
--- a/assets/helpers/icon-select.js
+++ b/assets/helpers/icon-select.js
@@ -55,6 +55,29 @@
     }
   }
 
+  // One global resize/scroll pair repositions whichever menu is OPEN. Per-wrap
+  // listeners leaked: wraps are recreated on pane rebuilds, so each rebuild
+  // added another unremovable pair pinning the dead wrap/menu.
+  function bindReposition() {
+    if (window[KEY]?.posBound) return;
+    window[KEY] = window[KEY] || {};
+    window[KEY].posBound = true;
+    const reposition = () => { if (OPEN) positionMenu(OPEN.wrap, OPEN.btn, OPEN.menu); };
+    window.addEventListener("resize", reposition);
+    window.addEventListener("scroll", reposition, true);
+  }
+
+  // Menus live on document.body, so they outlive their wrap when a settings
+  // pane is rebuilt via innerHTML; drop any menu whose wrap left the DOM.
+  function sweepOrphanMenus() {
+    d.querySelectorAll("body > .cw-icon-select-menu").forEach((menu) => {
+      const wrap = menu.__cwWrap;
+      if (!wrap || wrap.isConnected) return;
+      if (OPEN?.menu === menu) OPEN = null;
+      menu.remove();
+    });
+  }
+
   function bindAway() {
     if (window[KEY]?.awayBound) return;
     window[KEY] = window[KEY] || {};
@@ -303,6 +326,7 @@
     if (!select) return select;
     injectCss();
     bindAway();
+    sweepOrphanMenus();
     select.__cwIconSelectCfg = cfg;
 
     let wrap = select.nextElementSibling;
@@ -314,6 +338,7 @@
       const menu = d.createElement("div");
       menu.className = "cw-icon-select-menu hidden";
       menu.setAttribute("role", "listbox");
+      menu.__cwWrap = wrap;
       d.body.appendChild(menu);
       wrap.__cwMenu = menu;
       select.classList.add("cw-icon-select-native");
@@ -322,6 +347,7 @@
       const menu = d.createElement("div");
       menu.className = "cw-icon-select-menu hidden";
       menu.setAttribute("role", "listbox");
+      menu.__cwWrap = wrap;
       d.body.appendChild(menu);
       wrap.__cwMenu = menu;
     }
@@ -371,15 +397,7 @@
       });
       select.__cwOptionsObserver = obs;
     }
-    if (!wrap.dataset.cwPosBound) {
-      wrap.dataset.cwPosBound = "1";
-      window.addEventListener("resize", () => {
-        if (OPEN?.wrap === wrap) positionMenu(wrap, btn, menu);
-      });
-      window.addEventListener("scroll", () => {
-        if (OPEN?.wrap === wrap) positionMenu(wrap, btn, menu);
-      }, true);
-    }
+    bindReposition();
     return wrap;
   }
 

--- a/assets/helpers/icon-select.js
+++ b/assets/helpers/icon-select.js
@@ -70,17 +70,34 @@
   // Menus live on document.body, so they outlive their wrap when a settings
   // pane is rebuilt via innerHTML; drop any menu whose wrap left the DOM.
   // Callers may enhance selects inside a subtree that is not inserted yet
-  // (e.g. scheduler event rows build cells before appendChild), so only treat
-  // a wrap as orphaned after it has been seen connected at least once.
+  // (e.g. scheduler event rows build cells before appendChild), so a wrap
+  // becomes sweepable once seen connected, or — for wraps that are inserted
+  // and removed again between sweeps and are therefore never observed
+  // connected — after a detachment grace period.
+  const ORPHAN_GRACE_MS = 5000;
+  function markMenuConnected(wrap) {
+    const menu = wrap && wrap.__cwMenu;
+    if (menu && wrap.isConnected) {
+      menu.__cwWrapWasConnected = true;
+      menu.__cwDetachedSince = 0;
+    }
+  }
   function sweepOrphanMenus() {
+    const now = Date.now();
     d.querySelectorAll("body > .cw-icon-select-menu").forEach((menu) => {
       const wrap = menu.__cwWrap;
       if (!wrap) return;
       if (wrap.isConnected) {
-        menu.__cwWrapWasConnected = true;
+        markMenuConnected(wrap);
         return;
       }
-      if (!menu.__cwWrapWasConnected) return;
+      if (!menu.__cwWrapWasConnected) {
+        if (!menu.__cwDetachedSince) {
+          menu.__cwDetachedSince = now;
+          return;
+        }
+        if (now - menu.__cwDetachedSince < ORPHAN_GRACE_MS) return;
+      }
       if (OPEN?.menu === menu) OPEN = null;
       menu.remove();
     });
@@ -405,7 +422,10 @@
       });
       select.__cwOptionsObserver = obs;
     }
-    if (wrap.isConnected && wrap.__cwMenu) wrap.__cwMenu.__cwWrapWasConnected = true;
+    // Detached-enhanced wraps are usually appended later in the same task;
+    // the microtask marks them connected before any subsequent sweep runs.
+    if (wrap.isConnected) markMenuConnected(wrap);
+    else queueMicrotask(() => markMenuConnected(wrap));
     bindReposition();
     return wrap;
   }

--- a/assets/helpers/icon-select.js
+++ b/assets/helpers/icon-select.js
@@ -69,10 +69,18 @@
 
   // Menus live on document.body, so they outlive their wrap when a settings
   // pane is rebuilt via innerHTML; drop any menu whose wrap left the DOM.
+  // Callers may enhance selects inside a subtree that is not inserted yet
+  // (e.g. scheduler event rows build cells before appendChild), so only treat
+  // a wrap as orphaned after it has been seen connected at least once.
   function sweepOrphanMenus() {
     d.querySelectorAll("body > .cw-icon-select-menu").forEach((menu) => {
       const wrap = menu.__cwWrap;
-      if (!wrap || wrap.isConnected) return;
+      if (!wrap) return;
+      if (wrap.isConnected) {
+        menu.__cwWrapWasConnected = true;
+        return;
+      }
+      if (!menu.__cwWrapWasConnected) return;
       if (OPEN?.menu === menu) OPEN = null;
       menu.remove();
     });
@@ -397,6 +405,7 @@
       });
       select.__cwOptionsObserver = obs;
     }
+    if (wrap.isConnected && wrap.__cwMenu) wrap.__cwMenu.__cwWrapWasConnected = true;
     bindReposition();
     return wrap;
   }

--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -1344,6 +1344,23 @@
     deleteBtn?.classList.toggle("hidden", !info.deleteSelector);
   }
 
+  // Single window listener resolving live panels from the DOM. A per-panel
+  // listener leaked: panels are destroyed by slot.innerHTML rebuilds, so each
+  // modal open added another unremovable closure pinning the detached panel.
+  let connectionModalResizeBound = false;
+  function bindConnectionModalResize() {
+    if (connectionModalResizeBound) return;
+    connectionModalResizeBound = true;
+    window.addEventListener("resize", () => {
+      document.querySelectorAll(".cw-connection-modal-panel").forEach((panel) => {
+        const overlay = panel.closest(".cw-connection-overlay");
+        if (!overlay || overlay.classList.contains("hidden")) return;
+        const info = connectionInfoForKey(panel.dataset.cwConnectionKey);
+        if (info) scheduleConnectionModalSize(panel, info);
+      });
+    }, { passive: true });
+  }
+
   function enhanceConnectionModal(section, overlay, key) {
     const info = connectionInfoForKey(key);
     const panel = connectionPanelFor(section, info);
@@ -1378,12 +1395,7 @@
       resetConnectionModalScroll(panel);
       updateConnectionModalSize(panel, info);
     });
-    if (!panel.__cwConnectionModalResizeBound) {
-      panel.__cwConnectionModalResizeBound = true;
-      window.addEventListener("resize", () => {
-        if (panel.isConnected && !overlay?.classList?.contains("hidden")) scheduleConnectionModalSize(panel, info);
-      }, { passive: true });
-    }
+    bindConnectionModalResize();
     if (!panel.__cwConnectionModalObserveBound) {
       panel.__cwConnectionModalObserveBound = true;
       const onPanelChange = () => {

--- a/assets/helpers/whitelist_table.js
+++ b/assets/helpers/whitelist_table.js
@@ -90,13 +90,14 @@
             </div>
           </div>
         </div>`;
-      const stampEl = host.querySelector(".cw-wl-stamp");
+      // render() re-runs on every column toggle/load; without this the old
+      // 30s interval (and the DOM closure it retains) stacks per render.
+      if (host.__cwWlTimer) clearInterval(host.__cwWlTimer);
       host.__cwWlTimer = setInterval(() => {
         const el = host.querySelector(".cw-wl-stamp");
         if (!el) { clearInterval(host.__cwWlTimer); host.__cwWlTimer = 0; return; }
         el.textContent = stampText();
       }, 30000);
-      void stampEl;
     }
 
     async function doLoad(force, flash) {

--- a/assets/js/connections.pairs.overlay.js
+++ b/assets/js/connections.pairs.overlay.js
@@ -402,8 +402,16 @@ html[data-cw-theme="flat-light"] #pairs_list .icon-btn.power.off:hover{
   }
 
   function installTooltip(host) {
-    let tip = host.querySelector(".cx-tip");
-    if (!tip) { tip = document.createElement("div"); tip.className = "cx-tip"; host.appendChild(tip); }
+    // Wire once: host (#pairs_list) persists across renders, so re-adding
+    // listeners on every renderPairsOverlay() leaks them without bound.
+    if (host.__cxTipWired) return;
+    host.__cxTipWired = true;
+
+    const ensureTip = () => {
+      let tip = host.querySelector(".cx-tip");
+      if (!tip) { tip = document.createElement("div"); tip.className = "cx-tip"; host.appendChild(tip); }
+      return tip;
+    };
 
     let showTimer = 0;
 
@@ -412,6 +420,7 @@ html[data-cw-theme="flat-light"] #pairs_list .icon-btn.power.off:hover{
       const msg = el.getAttribute("data-tip") || el.getAttribute("aria-label") || el.getAttribute("title") || "";
       if (!msg) return;
       showTimer = setTimeout(() => {
+        const tip = ensureTip();
         tip.textContent = msg;
         tip.style.left = (ev.clientX + 10) + "px";
         tip.style.top = (ev.clientY + 10) + "px";
@@ -420,14 +429,15 @@ html[data-cw-theme="flat-light"] #pairs_list .icon-btn.power.off:hover{
     };
 
     const move = (ev) => {
-      if (!tip.classList.contains("on")) return;
+      const tip = host.querySelector(".cx-tip");
+      if (!tip || !tip.classList.contains("on")) return;
       tip.style.left = (ev.clientX + 10) + "px";
       tip.style.top = (ev.clientY + 10) + "px";
     };
 
     const hide = () => {
       clearTimeout(showTimer);
-      tip.classList.remove("on");
+      host.querySelector(".cx-tip")?.classList.remove("on");
     };
 
     host.addEventListener("pointerover", (e) => {

--- a/assets/js/modals/exporter/index.js
+++ b/assets/js/modals/exporter/index.js
@@ -47,13 +47,17 @@ function enableColumnResize(table,key="cw.exporter.cols.v2"){
 
 // Document-level listener must outlive mount() but not the modal; kept here so
 // unmount() can remove it — otherwise each open leaks a handler pinning the
-// discarded modal subtree.
-let onDocClick=null;
+// discarded modal subtree. The generation counter stops a stale mount (its
+// awaits still in flight when the modal is reopened or unmounted) from
+// wiring its handler over the live mount's.
+let onDocClick=null, mountGen=0;
 
 export default {
   async mount(root){
+    const gen=++mountGen;
     injectCSS();
     await injectExporterStyles();
+    if(gen!==mountGen) return;
     const shell=root.closest(".cx-modal-shell");
     shell?.classList.add("cw-exporter-modal");
     root.classList.add("cw-exporter-modal");
@@ -140,6 +144,7 @@ export default {
     const autoRefresh=debounce(()=>renderPreview(true),200), reset=cb=>()=>{state.selected.clear(); state.mode="all"; allChk.checked=true; cb?.(); savePrefs(); autoRefresh()};
     provBtn.addEventListener("click",e=>{e.stopPropagation(); provMenu.classList.contains("open")?closeProv():openProv()});
     provMenu.addEventListener("click",e=>{const btn=e.target.closest(".prov-opt"); if(!btn) return; provSel.value=btn.dataset.provider; closeProv(); reset(syncInstances)()});
+    if(gen!==mountGen) return;
     if(onDocClick) document.removeEventListener("click",onDocClick);
     onDocClick=e=>{if(!e.target.closest(".provider-field")) closeProv()};
     document.addEventListener("click",onDocClick);
@@ -158,6 +163,7 @@ export default {
     await renderPreview(false);
   },
   unmount(){
+    mountGen++;
     if(onDocClick){document.removeEventListener("click",onDocClick); onDocClick=null;}
   }
 };

--- a/assets/js/modals/exporter/index.js
+++ b/assets/js/modals/exporter/index.js
@@ -45,6 +45,11 @@ function enableColumnResize(table,key="cw.exporter.cols.v2"){
   }catch(err){console.warn("Column resize init failed:",err)}
 }
 
+// Document-level listener must outlive mount() but not the modal; kept here so
+// unmount() can remove it — otherwise each open leaks a handler pinning the
+// discarded modal subtree.
+let onDocClick=null;
+
 export default {
   async mount(root){
     injectCSS();
@@ -135,7 +140,9 @@ export default {
     const autoRefresh=debounce(()=>renderPreview(true),200), reset=cb=>()=>{state.selected.clear(); state.mode="all"; allChk.checked=true; cb?.(); savePrefs(); autoRefresh()};
     provBtn.addEventListener("click",e=>{e.stopPropagation(); provMenu.classList.contains("open")?closeProv():openProv()});
     provMenu.addEventListener("click",e=>{const btn=e.target.closest(".prov-opt"); if(!btn) return; provSel.value=btn.dataset.provider; closeProv(); reset(syncInstances)()});
-    document.addEventListener("click",e=>{if(!e.target.closest(".provider-field")) closeProv()});
+    if(onDocClick) document.removeEventListener("click",onDocClick);
+    onDocClick=e=>{if(!e.target.closest(".provider-field")) closeProv()};
+    document.addEventListener("click",onDocClick);
     instSel.addEventListener("change",reset());
     featSel.addEventListener("change",reset(()=>{syncFormats(); syncCapabilities(); syncWatchedDateOption()}));
     fmtSel.addEventListener("change",()=>{syncCapabilities(); syncWatchedDateOption(); savePrefs(); autoRefresh()});
@@ -150,5 +157,7 @@ export default {
     tbody.addEventListener("click",e=>{const tr=e.target.closest("tr[data-key]"); if(!tr||e.target.closest("input,button,select,.resizer")) return; const cb=$(".row-check",tr); if(cb){cb.checked=!cb.checked; cb.dispatchEvent(new Event("change",{bubbles:true}))}});
     await renderPreview(false);
   },
-  unmount(){}
+  unmount(){
+    if(onDocClick){document.removeEventListener("click",onDocClick); onDocClick=null;}
+  }
 };


### PR DESCRIPTION
## Summary

Fixes the five confirmed unbounded frontend leaks found in the memory audit (Safari was killing the page for excessive memory). Each site accumulated listeners/intervals whose closures pinned dead DOM subtrees, so memory grew monotonically during normal use.

- **`assets/js/connections.pairs.overlay.js`** — `installTooltip()` ran at the tail of every `renderPairsOverlay()` and re-added 4 listeners on the persistent `#pairs_list` host plus a `window` scroll listener each time. Now wires once (`host.__cxTipWired`) and resolves the tooltip element lazily so a rebuilt tip still works.
- **`assets/helpers/whitelist_table.js`** — `render()` overwrote `host.__cwWlTimer` without clearing the previous 30s interval; every column toggle / library load stacked another interval retaining the old DOM closure. Now clears before re-arming. Also removed the dead `void stampEl` reference.
- **`assets/js/modals/exporter/index.js`** — `mount()` added a `document` click listener and `unmount()` was empty, leaking one handler (and the whole modal subtree via its closure) per open. Handler is now tracked at module level and removed in `unmount()`.
- **`assets/helpers/icon-select.js`** — each recreated wrap (settings-pane `innerHTML` rebuilds retrigger `enhance()` via the body MutationObserver) added an unremovable `window` resize + capture scroll pair, and popup menus appended to `document.body` were orphaned forever. Replaced with one global reposition pair keyed to the currently open menu, plus an orphan-menu sweep that removes body-level menus whose wrap left the DOM.
- **`assets/helpers/providers-ui.js`** — every connection-modal open added a `window` resize listener guarded by a flag on the panel, which dies when `mountAuthProviders()` rebuilds the slot via `innerHTML`. Replaced with one module-level listener that resolves live panels from the DOM (`.cw-connection-modal-panel` inside a non-hidden `.cw-connection-overlay`).

## Testing

- `node --check` passes on all five files.
- No behavioral change intended: tooltip, stamp refresh, exporter provider dropdown dismiss, icon-select menu repositioning, and connection-modal resizing all keep working through their existing code paths.
- Manual verification suggestion: open Settings and flip between panes / open+close the exporter repeatedly, then snapshot listeners via Safari Web Inspector — counts should stay flat.

> PR authored by an AI agent (Claude Code) from the memory/CPU audit in this repo.

https://claude.ai/code/session_01MmgvbUt1V5B3BTm26sKHD9