### PR TITLE
perf(ui): stop hidden-tab poll churn and redundant lane rebuilds

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -464,6 +464,11 @@
       lane.appendChild(body);
       wrap.appendChild(lane);
     }
+    // Polling re-renders identical payloads; skip the live-DOM swap (and its
+    // style/layout invalidation + repaint) when nothing visible changed.
+    const html = wrap.innerHTML;
+    if (html === renderLanes._lastHtml && elLanes.firstChild) return;
+    renderLanes._lastHtml = html;
     elLanes.replaceChildren(wrap);
   }
 
@@ -752,6 +757,7 @@
     if (authSetupPending()) return;
     summaryStream.onVisibility();
     openLogStream();
+    tick();
   });
 
   window.addEventListener("auth-changed", () => {
@@ -770,6 +776,15 @@
   });
 
   async function tick() {
+    if (document.hidden) {
+      // SSE closes on hide (summaryStream.onVisibility), which flips sseUp
+      // false and turned this loop into a fetch + full lanes rebuild every 6s
+      // for as long as the tab was backgrounded. Idle until visible again;
+      // the visibilitychange handler re-syncs immediately on return.
+      clearTimeout(tick._t);
+      tick._t = setTimeout(tick, 30000);
+      return;
+    }
     if (authSetupPending()) {
       try { esSummary?.close?.(); } catch {}
       esSummary = null;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -455,7 +455,11 @@
           more.style.marginLeft = "auto";
           more.addEventListener("click", (ev) => {
             ev.stopPropagation();
-            openSpotsModal(feat.label, { add: spotAdd, rem: spotRem, upd: spotUpd });
+            // Read the lane fresh: the render skip below can keep this
+            // listener alive across summaries whose visible rows are
+            // identical but whose full spotlight lists changed.
+            const cur = getLaneStats(summary || {}, feat.key);
+            openSpotsModal(feat.label, { add: cur.spotAdd, rem: cur.spotRem, upd: cur.spotUpd });
           });
           lastRow.appendChild(more);
         }


### PR DESCRIPTION
## Summary

Second PR from the memory/CPU audit (Safari killing the page for excessive memory). Targets the single most expensive recurring cost found: the main-page `tick()` loop in `assets/js/main.js`.

- **Hidden-tab churn**: the `visibilitychange` handler closes the summary EventSource when the tab hides, which made `sseUp` false inside `tick()` — so a backgrounded tab fell through to `pullSummary()` (fetch + JSON parse) followed by a full lanes DOM teardown/rebuild **every 6 seconds, indefinitely**. Backgrounding the tab upgraded a passive SSE into active polling. `tick()` now idles on a 30s heartbeat while `document.hidden`, and the visibility handler calls `tick()` on return so cadence resumes immediately (the stream controller already re-opens SSE and pulls a fresh summary at that moment).
- **Redundant rebuilds**: `renderLanes()` rebuilt the whole `.lanes` subtree and `replaceChildren()`-swapped it into the live DOM on every poll tick with no dirty check — identical payloads still paid style/layout invalidation and repaint. The rebuilt subtree's HTML is now compared to the last applied render; the live-DOM swap is skipped when nothing visible changed. (The subtree is still built off-DOM, so all state bookkeeping — `lastCounts`, shake detection — behaves exactly as before; any visible difference, including the shake class or delta text, changes the HTML and forces the swap.)

## Testing

- `node --check assets/js/main.js` passes.
- Behavior to verify manually: main page lanes still update during a sync run; backgrounding the tab for a few minutes then returning shows fresh data (visibility handler pulls immediately); Safari/Chrome timeline shows no recurring 6s fetch+layout work while hidden.

> PR authored by an AI agent (Claude Code) from the memory/CPU audit in this repo. Independent of PR #66; both merge cleanly to main.

https://claude.ai/code/session_01MmgvbUt1V5B3BTm26sKHD9