### PR TITLE
perf(ui): reduce background timer wakeups and redundant refresh work

### DIFF
--- a/assets/auth/auth.trakt.js
+++ b/assets/auth/auth.trakt.js
@@ -258,7 +258,16 @@
 
     try {
       if (!window.__traktBannerTick) {
-        window.__traktBannerTick = setInterval(function(){ try { updateTraktBanner(); } catch (_) {} }, 800);
+        // Skip ticks while the tab is hidden or Settings is not on screen;
+        // this interval is never cleared, so idle cost must stay near zero.
+        window.__traktBannerTick = setInterval(function(){
+          try {
+            if (document.hidden) return;
+            var page = _el("page-settings");
+            if (!page || page.classList.contains("hidden")) return;
+            updateTraktBanner();
+          } catch (_) {}
+        }, 800);
       }
     } catch (_) {}
   }

--- a/assets/helpers/details-log.js
+++ b/assets/helpers/details-log.js
@@ -721,6 +721,7 @@ function openDebugLog() {
 
     if (window._debugStaleIV) clearInterval(window._debugStaleIV);
     window._debugStaleIV = setInterval(() => {
+      if (document.hidden) return;
       const stale = (Date.now() - lastMsgAt) > 20000;
       tabDebug?.classList.toggle("stale", stale);
       _updateDetailsConsoleStatus();
@@ -830,6 +831,7 @@ async function openWatcherLog() {
 
     if (window._watchStaleIV) clearInterval(window._watchStaleIV);
     window._watchStaleIV = setInterval(() => {
+      if (document.hidden) return;
       const stale = (Date.now() - lastMsgAt) > 20000;
       tabWatch?.classList.toggle("stale", stale);
       _updateDetailsConsoleStatus();

--- a/assets/js/activity.js
+++ b/assets/js/activity.js
@@ -210,7 +210,10 @@
     if (!block || !host) return;
 
     if (authSetupPending()) {
-      if (!host.children.length) host.innerHTML = `<div class="activity-empty">Loading scrobble...</div>`;
+      if (!host.children.length) {
+        host.__cwLastHtml = `<div class="activity-empty">Loading scrobble...</div>`;
+        host.innerHTML = host.__cwLastHtml;
+      }
       scheduleRetry();
       return;
     }
@@ -229,12 +232,18 @@
         throw new Error("invalid_activity_response");
       }
       const items = data.items;
-      host.innerHTML = items.length
+      const html = items.length
         ? items.map((item) => rowHTML(item)).join("")
         : `<div class="activity-empty">${display.mode === "hours" ? `No recent scrobble in the last ${display.hours} hours.` : "No recent scrobble yet."}</div>`;
+      // Most 60s ticks return identical data; skip the list rebuild then.
+      if (host.__cwLastHtml !== html) {
+        host.__cwLastHtml = html;
+        host.innerHTML = html;
+      }
     } catch {
       if (!host.children.length || host.textContent.trim() === "Loading scrobble...") {
-        host.innerHTML = `<div class="activity-empty">Recent scrobble could not be loaded.</div>`;
+        host.__cwLastHtml = `<div class="activity-empty">Recent scrobble could not be loaded.</div>`;
+        host.innerHTML = host.__cwLastHtml;
       }
       scheduleRetry(2500);
     }
@@ -401,7 +410,12 @@
     injectCSS();
     bindViewAllButton();
     refreshRecentActivity();
-    if (!refreshTimer) refreshTimer = setInterval(refreshRecentActivity, 60000);
+    if (!refreshTimer) {
+      refreshTimer = setInterval(() => { if (!document.hidden) refreshRecentActivity(); }, 60000);
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible") refreshRecentActivity();
+      });
+    }
   }
 
   if (document.readyState === "loading") {

--- a/assets/js/main-status.js
+++ b/assets/js/main-status.js
@@ -128,10 +128,12 @@
 
   window.syncMetadataProviderDot = syncMetadataProviderDot;
 
-  function observeMeta(fn) {
+  function observeMeta(fn, delay = 150) {
     const host = $("meta-tmdb-dot");
     if (!host) {
-      setTimeout(() => observeMeta(fn), 150);
+      // The dot only exists once the Settings metadata panel renders, which
+      // may be never; back off instead of spinning at 150ms for the session.
+      setTimeout(() => observeMeta(fn, Math.min(5000, delay * 2)), delay);
       return;
     }
     fn();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1059,6 +1059,8 @@
   document.addEventListener("tab-changed", syncVisibility);
   document.addEventListener("config-saved", syncVisibility);
   window.addEventListener("load", syncVisibility, { once: true });
-  window.setInterval(syncVisibility, 1500);
+  // Safety net only — resize/visibility/tab/config events above cover every
+  // known state change, so poll slowly and never while hidden.
+  window.setInterval(() => { if (!document.hidden) syncVisibility(); }, 10000);
   refreshSoon();
 })();


### PR DESCRIPTION
## Summary

Fourth PR from the memory/CPU audit. The audit found only 2 of 24 `setInterval` sites consult `document.hidden`; everything else keeps running at full cadence in a backgrounded tab. This PR fixes the worst offenders (the main `tick()` loop was already handled in #67):

- **`assets/js/main-status.js`** — `observeMeta()` polled for `#meta-tmdb-dot` every 150ms with no cap; the element only exists once the Settings metadata panel renders, so a session that never opened Settings spun at ~6.7 wakeups/sec forever. Now backs off exponentially (150ms → 5s cap), still attaching whenever the panel eventually appears.
- **`assets/auth/auth.trakt.js`** — the 800ms banner tick starts on Trakt init and is never cleared anywhere. It now skips work unless the tab is visible **and** the Settings page is on screen (same pause condition the shared device-poll helper uses).
- **`assets/js/main.js`** — the quick-add `syncVisibility` 1.5s poll duplicated a complete event set (`resize`, `visibilitychange`, `tab-changed`, `config-saved`, `load`). Kept as a safety net at 10s, hidden-guarded.
- **`assets/js/activity.js`** — the 60s recent-activity refresh fetched `/api/activity/recent` and rebuilt the list via `innerHTML` on every tick regardless of visibility or payload equality. Now: hidden ticks skip entirely, returning to visible triggers an immediate refresh, and the DOM is only touched when the rendered HTML differs from the last applied render (all three `innerHTML` writers keep the cache coherent, so an error banner can't mask a later identical success render).
- **`assets/helpers/details-log.js`** — both 1s stale-check intervals (watcher + debug tabs) ran `_updateDetailsConsoleStatus()` — which reads `childElementCount` and forces layout — while hidden. Now no-op until visible. (Their reconnect paths already checked visibility.)

Deliberately left alone: the scheduler-banner 1s visual tick (already hidden-guarded and gated on active playback — it drives the progress bar; and `stop()` runs on every `refresh()`, so clearing it there would kill it permanently), and the 30s text-only pill updaters in watchlist/editor (negligible).

## Testing

- `node --check` passes on all five files.
- Manual: Trakt banner still locks/unlocks connect buttons on Settings; recent-activity widget updates on return to a backgrounded tab; metadata dot still appears when opening Settings late in a session.

> PR authored by an AI agent (Claude Code) from the memory/CPU audit in this repo. Independent of #66/#67/#68; touches different regions of `main.js`/`details-log.js` than #67/#68 so no conflicts expected.

https://claude.ai/code/session_01MmgvbUt1V5B3BTm26sKHD9