### PR TITLE
fix(logs): stop unbounded log-buffer growth from reader endpoints

### DIFF
--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -75,7 +75,6 @@
   const PAIRS_CACHE_KEY = "cw.pairs.v1";
   const PAIRS_TTL_MS = 15_000;
   const STATUS_CACHE_KEY = "cw.status.v1";
-  const DETAILS_MAX_LINES = 2500;
   const authSetupPending = () => window.cwIsAuthSetupPending?.() === true;
   const ROUTE_TABS = new Set(["main", "watchlist", "playback_progress", "snapshots", "playlists", "editor", "settings"]);
   const SETTINGS_PANES = new Set(["overview", "providers", "sync", "scrobbler", "scheduling", "app", "maintenance"]);
@@ -1928,7 +1927,7 @@ Object.assign(window, {
   computeRedirectURI, recomputeRunDisabled, relTimeFromEpoch,
   showTab, toggleSection, runSync,
   copySummary, loadPairs, cxSavePair,
-  cwToggleSyncMenu, DETAILS_MAX_LINES,
+  cwToggleSyncMenu,
 });
 CW.checkForUpdate = checkForUpdate;
 

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -579,8 +579,16 @@ def _norm_log_tag(tag: str | None) -> str:
         return "SYNC"
     return t
 
-def _get_log_buf(tag: str | None) -> List[str]:
+def _get_log_buf(tag: str | None, *, create: bool = True) -> List[str]:
+    """Return the buffer for ``tag``.
+
+    Readers must pass ``create=False``: the tag flows straight from query
+    strings, and setdefault would permanently add a buffer (plus seq entries)
+    per distinct value — unbounded, client-driven memory growth.
+    """
     t = _norm_log_tag(tag)
+    if not create and t not in LOG_BUFFERS:
+        return []
     buf = LOG_BUFFERS.setdefault(t, [])
     if t not in LOG_NEXT_SEQ:
         LOG_NEXT_SEQ[t] = 1
@@ -591,7 +599,7 @@ def _get_log_buf(tag: str | None) -> List[str]:
     return buf
 
 def _log_lines(tag: str | None, tail: int | None = None) -> List[str]:
-    buf = _get_log_buf(tag)
+    buf = _get_log_buf(tag, create=False)
     if not tail:
         return list(buf)
     return buf[-int(tail):]
@@ -936,7 +944,7 @@ async def api_logs_stream_initial(
     tag = _norm_log_tag(tag)
 
     async def agen():
-        buf = list(_get_log_buf(tag))
+        buf = list(_get_log_buf(tag, create=False))
         base = int(LOG_BASE_SEQ.get(tag, int(LOG_NEXT_SEQ.get(tag, 1))))
         if since is not None:
             last_seq = max(int(since), base - 1)
@@ -954,7 +962,7 @@ async def api_logs_stream_initial(
         while True:
             if await request.is_disconnected():
                 break
-            new_buf = _get_log_buf(tag)
+            new_buf = _get_log_buf(tag, create=False)
             base = int(LOG_BASE_SEQ.get(tag, int(LOG_NEXT_SEQ.get(tag, 1))))
             if last_seq < base - 1:
                 last_seq = base - 1
@@ -998,7 +1006,7 @@ async def api_logs_watcher(
         last_seq: Dict[str, int] = {}
 
         for t in tags_sel:
-            buf = _get_log_buf(t)
+            buf = _get_log_buf(t, create=False)
             start = max(0, len(buf) - int(tail))
             for line in buf[start:]:
                 safe = _log_stream_text(line, plain)
@@ -1012,7 +1020,7 @@ async def api_logs_watcher(
                 break
 
             for t in tags_sel:
-                buf = _get_log_buf(t)
+                buf = _get_log_buf(t, create=False)
                 base = int(LOG_BASE_SEQ.get(t, int(LOG_NEXT_SEQ.get(t, 1))))
                 seen = int(last_seq.get(t, base - 1))
                 if seen < base - 1:

--- a/tests/test_log_buffer_bounds.py
+++ b/tests/test_log_buffer_bounds.py
@@ -1,0 +1,44 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def cw(config_base):
+    import crosswatch
+
+    return crosswatch
+
+
+def test_reader_does_not_create_buffer_for_unknown_tag(cw) -> None:
+    tag = "NOTAREALTAG"
+    assert tag not in cw.LOG_BUFFERS
+
+    assert cw._get_log_buf(tag, create=False) == []
+    assert tag not in cw.LOG_BUFFERS
+    assert tag not in cw.LOG_NEXT_SEQ
+    assert tag not in cw.LOG_BASE_SEQ
+
+    assert cw._log_lines(tag) == []
+    assert tag not in cw.LOG_BUFFERS
+
+
+def test_logs_dump_does_not_create_buffer(cw) -> None:
+    tag = "ANOTHERFAKETAG"
+    body = cw.logs_dump(channel=tag, n=10)
+    assert body == {"channel": tag, "lines": []}
+    assert tag not in cw.LOG_BUFFERS
+
+
+def test_writer_still_creates_and_reader_sees_lines(cw) -> None:
+    tag = "WRITERTAG"
+    try:
+        cw._append_log_to_buffer(tag, "hello")
+        assert tag in cw.LOG_BUFFERS
+        assert len(cw._get_log_buf(tag, create=False)) == 1
+        assert len(cw._log_lines(tag)) == 1
+    finally:
+        cw.LOG_BUFFERS.pop(tag, None)
+        cw.LOG_NEXT_SEQ.pop(tag, None)
+        cw.LOG_BASE_SEQ.pop(tag, None)


### PR DESCRIPTION
## Summary

Fifth and final PR from the memory/CPU audit.

**Backend — the only truly monotonic leak found (`crosswatch.py`)**
`_get_log_buf()` used `LOG_BUFFERS.setdefault(tag, [])`, and the tag flows straight from query strings: `/api/logs/stream?tag=...`, `/api/logs/dump?channel=...`, `/api/logs/watcher`. Every distinct value permanently added a buffer (each capped at 3000 lines) plus `LOG_NEXT_SEQ`/`LOG_BASE_SEQ` entries — unbounded, client-driven server memory growth with no reclamation. Readers now pass `create=False` and receive an empty list for unknown tags; only the write path (`_append_log_to_buffer`) creates buffers, so sequence bookkeeping is untouched. (The watcher endpoint's tags were already whitelisted via `_watch_log_selection`; it gets `create=False` too for consistency.)

**Frontend — log console retained ~4× the intended lines**
`assets/helpers/details-log.js` documents a 600-line default for `window.DETAILS_MAX_LINES`, but `ui_frontend.py` loads `core.js` first, which exported `DETAILS_MAX_LINES = 2500` onto `window` (the constant is used nowhere else in `core.js`). The 600 default therefore never applied, and each retained line is held twice on the client (DOM row + `_detSeenLines` dedupe string) — so ~5000 strings where ~1200 were intended. `core.js` no longer defines it; `details-log.js` owns the default, still overridable by setting `window.DETAILS_MAX_LINES` before load. **Note:** this reduces visible sync-log scrollback from 2500 to 600 lines — if 2500 was deliberate, say so and I'll keep the number and just single-source it instead.

## Testing

- New `tests/test_log_buffer_bounds.py`: unknown tags don't create buffers via `_get_log_buf(create=False)`, `_log_lines`, or the `logs_dump` endpoint; writer path still creates and readers then see the lines.
- Full `pytest`: 890 passed, 6 failed — same 6 failures exist on clean `main` (unrelated: `test_playlists_ui`, `test_meta_api_episode_stills`, `test_nuvio_discovery_branding`).
- `python -m py_compile crosswatch.py`, `node --check assets/helpers/core.js` pass.

> PR authored by an AI agent (Claude Code) from the memory/CPU audit in this repo. Independent of #66–#69.

https://claude.ai/code/session_01MmgvbUt1V5B3BTm26sKHD9