### PR TITLE
fix(sse): generation-scoped resume cursor for summary stream

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -2258,6 +2258,26 @@ _SSE_HEARTBEAT_SEC = 15.0
 _SSE_HEARTBEAT_COMMENT = ": keep-alive\n\n"
 
 
+# Identifies this process's sequence space. Cursors are "<gen>:<seq>"; a
+# cursor minted by a previous process fails the generation match and falls
+# back to a full replay, regardless of how its numeric part compares to the
+# new process's counters.
+_STREAM_GEN = uuid.uuid4().hex[:12]
+
+
+def _parse_resume_cursor(value: Any) -> int:
+    s = str(value or "").strip()
+    if not s:
+        return 0
+    gen, _, seq = s.rpartition(":")
+    if gen != _STREAM_GEN:
+        return 0
+    try:
+        return max(0, int(seq))
+    except ValueError:
+        return 0
+
+
 def _sync_log_base_seq() -> int:
     """Absolute sequence number of the first line currently in the SYNC buffer."""
     import sys, importlib
@@ -2268,7 +2288,7 @@ def _sync_log_base_seq() -> int:
 
 
 @router.get("/run/summary/stream")
-async def api_run_summary_stream(request: Request, since: int = 0) -> StreamingResponse:
+async def api_run_summary_stream(request: Request, since: str = "") -> StreamingResponse:
     import html, re
     TAG_RE = re.compile(r"<[^>]+>")
 
@@ -2327,16 +2347,12 @@ async def api_run_summary_stream(request: Request, since: int = 0) -> StreamingR
     # fresh page loads; anything else skips already-delivered lines so a
     # flapping connection no longer re-parses and re-emits the whole 3000-line
     # SYNC buffer on every reconnect.
-    resume_seq = 0
     try:
-        resume_seq = max(0, int(request.headers.get("last-event-id") or 0))
+        resume_seq = _parse_resume_cursor(request.headers.get("last-event-id"))
     except Exception:
         resume_seq = 0
     if not resume_seq:
-        try:
-            resume_seq = max(0, int(since or 0))
-        except Exception:
-            resume_seq = 0
+        resume_seq = _parse_resume_cursor(since)
 
     async def agen():
         last_key = None
@@ -2377,7 +2393,7 @@ async def api_run_summary_stream(request: Request, since: int = 0) -> StreamingR
                             except Exception:
                                 continue
                             evt = (str(obj.get("event") or "log").strip() or "log")
-                            yield f"id: {base + start_idx + j}\n"
+                            yield f"id: {_STREAM_GEN}:{base + start_idx + j}\n"
                             yield f"event: {evt}\n"
                             yield f"data: {json.dumps(obj, separators=(',',':'))}\n\n"
                             emitted = True
@@ -2385,9 +2401,9 @@ async def api_run_summary_stream(request: Request, since: int = 0) -> StreamingR
                     # Cursor marker: the client advances its resume position
                     # from this event alone, so consumed batches count even
                     # when their event types have no UI listener.
-                    yield f"id: {last_seq}\n"
+                    yield f"id: {_STREAM_GEN}:{last_seq}\n"
                     yield "event: cw:seq\n"
-                    yield f"data: {last_seq}\n\n"
+                    yield f"data: {_STREAM_GEN}:{last_seq}\n\n"
             except Exception:
                 pass
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -75,14 +75,14 @@
   let spotsModal = null;
   let esSummary = null;
   // Resume cursor for the summary stream, passed as ?since= on reopen so the
-  // server skips the full SYNC-buffer replay on every reconnect. Assigned (not
-  // maxed) from the dedicated cw:seq marker: after a backend restart the
-  // sequence space starts over, so a smaller id is newer, and the server
-  // treats an ahead-of-buffer cursor as stale either way.
-  let lastSummarySeq = 0;
+  // server skips the full SYNC-buffer replay on every reconnect. Opaque
+  // "<generation>:<seq>" token minted by the server: a cursor from a previous
+  // backend process fails the generation match server-side, so restarts fall
+  // back to a full replay instead of skipping a prefix of the new buffer.
+  let lastSummarySeq = "";
   const trackSummarySeq = (ev) => {
-    const n = Number(ev?.lastEventId);
-    if (Number.isFinite(n) && n > 0) lastSummarySeq = n;
+    const v = String(ev?.lastEventId || "");
+    if (v) lastSummarySeq = v;
   };
   let esLogs = null;
   let runButtonWired = false;
@@ -709,7 +709,7 @@
       safe(esSummary?.close?.bind(esSummary));
       const url = new URL("/api/run/summary/stream", document.baseURI);
       url.searchParams.set("_ts", String(nowTs()));
-      if (lastSummarySeq > 0) url.searchParams.set("since", String(lastSummarySeq));
+      if (lastSummarySeq) url.searchParams.set("since", lastSummarySeq);
       esSummary = new EventSource(url.toString());
       window.esSum = esSummary;
       esSummary.onmessage = (ev) => {

--- a/tests/test_summary_stream_cursor.py
+++ b/tests/test_summary_stream_cursor.py
@@ -1,0 +1,17 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+from api import syncAPI
+
+
+def test_parse_resume_cursor_accepts_current_generation() -> None:
+    assert syncAPI._parse_resume_cursor(f"{syncAPI._STREAM_GEN}:42") == 42
+
+
+def test_parse_resume_cursor_rejects_foreign_or_malformed() -> None:
+    assert syncAPI._parse_resume_cursor("deadbeef0000:42") == 0
+    assert syncAPI._parse_resume_cursor("42") == 0
+    assert syncAPI._parse_resume_cursor("") == 0
+    assert syncAPI._parse_resume_cursor(None) == 0
+    assert syncAPI._parse_resume_cursor(f"{syncAPI._STREAM_GEN}:notanum") == 0
+    assert syncAPI._parse_resume_cursor(f"{syncAPI._STREAM_GEN}:-5") == 0


### PR DESCRIPTION
## Summary

Follow-up to #68 (merged), addressing the post-merge Codex finding: the numeric `last_seq > newest` staleness check only catches a cursor from a previous backend process while the new process is still numerically behind it. If the page stayed hidden long enough for the restarted backend to emit at least that many records, the old cursor passed as valid and a prefix of the new buffer — including initialization and progress events — was silently skipped.

- **Server (`api/syncAPI.py`)**: resume cursors are now opaque `<generation>:<seq>` tokens, where the generation is a per-process `uuid4` fragment. `_parse_resume_cursor()` rejects any cursor whose generation doesn't match the running process (including bare-number cursors from clients that predate this change), falling back to the historic full replay. All `id:` frames and the `cw:seq` marker carry the token. The numeric ahead-of-buffer guard from #68 remains as a second layer.
- **Client (`assets/js/main.js`)**: the cursor is treated as an opaque string — assigned from `lastEventId`, passed back verbatim as `?since=`. No parsing client-side.

## Testing

- New `tests/test_summary_stream_cursor.py`: current-generation cursors parse to their sequence; foreign-generation, bare-number, malformed, and negative cursors all reject to 0 (full replay).
- Full `pytest`: 892 passed, 6 failed — same 6 pre-existing failures on `main` (`test_playlists_ui`, `test_meta_api_episode_stills`, `test_nuvio_discovery_branding`).
- `python -m py_compile` and `node --check` pass.

> PR authored by an AI agent (Claude Code), addressing review feedback left on #68 after merge.

https://claude.ai/code/session_01MmgvbUt1V5B3BTm26sKHD9