### PR TITLE
fix(license): ship modification notice and fork labels in the image

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -24,6 +24,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # metadata-action's auto-generated title/description come from the GitHub
+      # repo metadata and are passed to build-push-action as --label, which wins
+      # over the Dockerfile's LABEL. Restate the fork disclaimer here so the dev
+      # image cannot end up implying upstream endorsement (License Section 11).
       - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         id: meta
         with:
@@ -31,6 +35,10 @@ jobs:
           tags: |
             type=raw,value=dev
             type=sha,prefix=dev-
+          labels: |
+            org.opencontainers.image.title=CrossWatch (unofficial fork)
+            org.opencontainers.image.description=Unofficial fork of cenodude/CrossWatch. One brain for all your media syncs, a single place to configure everything. Not endorsed by the upstream Copyright Holder.
+            org.opencontainers.image.licenses=LicenseRef-CrossWatch-Source-Available-1.0
 
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,15 @@ RUN mkdir -p /config-skel
 # =====================================================================
 FROM dhi.io/python:3.14.6-alpine3.24
 
-LABEL org.opencontainers.image.description="One brain for all your media syncs A single place to configure everything."
+# Section 11 of the CrossWatch Source Available License forbids implying that a
+# modified version is endorsed by the Copyright Holder, so the description says
+# up front that this is an unofficial fork. The licenses label is the SPDX-style
+# hint scanners read; NOTICE (copied in with the app below) carries the
+# Section 6.3 statement of material modifications.
+LABEL org.opencontainers.image.title="CrossWatch (unofficial fork)" \
+      org.opencontainers.image.description="Unofficial fork of cenodude/CrossWatch. One brain for all your media syncs, a single place to configure everything. Not endorsed by the upstream Copyright Holder." \
+      org.opencontainers.image.source="https://github.com/jabrown93/CrossWatch" \
+      org.opencontainers.image.licenses="LicenseRef-CrossWatch-Source-Available-1.0"
 
 # Baked in by CI (jabrown93/.github/docker-release.yml passes
 # --build-arg APP_VERSION=v<version>); api/versionAPI.py reads this via
@@ -72,6 +80,9 @@ COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
 # Application code (.dockerignore keeps .git/__pycache__/.venv/tests out).
+# LICENSE and NOTICE ride along deliberately: License Section 6 requires every
+# distributed copy to carry the copyright notice, the full license text, and a
+# clear notice of material modifications. Do not add either to .dockerignore.
 COPY . /app
 
 # Writable runtime dir owned by the nonroot runtime user. Named volumes

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,34 @@
+CrossWatch
+Copyright (c) Cenodude
+https://github.com/cenodude/CrossWatch
+
+Licensed under the CrossWatch Source Available License, Version 1.0.
+The complete license text ships alongside this file as LICENSE.
+
+MODIFICATIONS
+=============
+
+This is an UNOFFICIAL, MODIFIED distribution maintained by Jared Brown at
+https://github.com/jabrown93/CrossWatch. It is not approved, sponsored,
+maintained, or endorsed by the Copyright Holder.
+
+Material changes relative to upstream cenodude/CrossWatch:
+
+- Security hardening: secrets redacted from config output and logs; outbound
+  provider requests guarded against SSRF on every redirect hop (which also
+  covers Jellyfin Quick Connect); unrecognized webhook profile tokens rejected
+  with a logged 401 instead of a silent 200.
+- Bug fixes: ID-mapping corrections (IMDb preferred over TMDb in match
+  priority; Jellyfin `ProviderIds` mapped).
+- CI and automation: pytest suite in GitHub Actions, automated container image
+  and GitHub Release publishing, semantic-release versioning, Renovate with
+  SHA-pinned actions.
+- Container: built on the shell-less, nonroot Docker Hardened Image Python
+  runtime rather than `python:slim`; the dynamic PUID/PGID bash entrypoint has
+  been removed.
+- Android companion app removed (dropped upstream in v0.10.3); leftover paired
+  device tokens are purged on the next credential rotation.
+
+The container images published at ghcr.io/jabrown93/crosswatch are distributed
+free of charge under Sections 3 and 5 of the License. No fee of any kind is
+charged for access to or use of the Software.

--- a/NOTICE
+++ b/NOTICE
@@ -14,6 +14,10 @@ maintained, or endorsed by the Copyright Holder.
 
 Material changes relative to upstream cenodude/CrossWatch:
 
+- Authentication: an OIDC/SSO login provider (`api/authOIDCAPI.py`,
+  `services/authOIDC.py`), static API-key authentication over an `x-api-key`
+  header for programmatic access, and a first-run setup-token gate
+  (`api/appAuthAPI.py`). None of these exist upstream.
 - Security hardening: secrets redacted from config output and logs; outbound
   provider requests guarded against SSRF on every redirect hop (which also
   covers Jellyfin Quick Connect); unrecognized webhook profile tokens rejected

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 >
 > **Differences from upstream:**
 >
+> - **Authentication** — OIDC/SSO login, static API-key auth via an `x-api-key` header for
+>   programmatic access, and a first-run setup-token gate. None of these exist upstream.
 > - **Security hardening** — secrets are redacted from config output/logs, outbound provider
 >   requests are guarded against SSRF (including on every redirect hop, which also covers
 >   Jellyfin Quick Connect), and an unrecognized webhook profile token is rejected with a


### PR DESCRIPTION
## Why

The published `ghcr.io/jabrown93/crosswatch` image is publicly pullable, so it is a **distribution** under the CrossWatch Source Available License, not internal use.

Free public distribution is expressly permitted (§3.3, §5 — no fee is charged), and the image already carried `LICENSE` because `COPY . /app` picks it up. The gap was §6.3: every distributed copy of a *modified* version must carry "a clear notice identifying material modifications". The fork diff lives in `README.md`, which `.dockerignore` excludes, so that notice never reached the image.

Separately, §11 forbids implying that a modified version is endorsed by the Copyright Holder, and the image described itself with upstream's tagline under upstream's name.

## What

- New `NOTICE` at repo root: upstream copyright, fork provenance, the material changes, and a statement that the images are distributed free of charge under §§3 and 5. Rides into the image via the existing `COPY . /app` (not `.dockerignore`d — there is now a comment saying not to add it).
- Dockerfile labels restate the fork disclaimer, point `source` at this repo, and set `org.opencontainers.image.licenses=LicenseRef-CrossWatch-Source-Available-1.0`.
- `dev-image.yml` passes the same labels through `metadata-action`, whose auto-generated title/description are emitted as `--label` and would otherwise override the Dockerfile's `LABEL`. `release.yml` uses `jabrown93/ci/docker-release.yml`, which sets no labels, so it inherits the Dockerfile's.

## Verification

Built locally and inspected the resulting image:

- `/app/LICENSE` → `# CrossWatch Source Available License`
- `/app/NOTICE` → `CrossWatch / Copyright (c) Cenodude`
- labels → `org.opencontainers.image.title="CrossWatch (unofficial fork)"`, description carrying "Not endorsed by the upstream Copyright Holder"

Typed `fix(license)` so semantic-release cuts a patch and the corrected image actually gets published.

> Authored by Claude (AI agent) at the repo owner's direction. Not legal advice.

https://claude.ai/code/session_017qxZZoY24YG4y6KRePP6Zg