### PR TITLE
feat(config): accept environment variables for OIDC and any config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,54 @@ volumes:
 > The container exposes the web UI at:\
 > http://localhost:8787
 
+### Configuration from the environment
+
+Any setting can be supplied as an environment variable instead of being typed into the UI.
+Environment values win over `config.json` and are **never written to it**, so a secret from a
+Docker secret or Kubernetes Secret stays out of the config volume. Unset the variable and the
+field reverts to whatever the file held.
+
+Fields owned by the environment are shown disabled in the UI, labelled with the variable that
+owns them; a save that tried to change one reports which fields it discarded.
+
+Single sign-on and machine access have short names:
+
+| Variable | Setting |
+| --- | --- |
+| `CW_OIDC_ENABLED` | Offer OIDC login (`true` / `false`) |
+| `CW_OIDC_ISSUER` | Issuer URL — trailing slash is significant |
+| `CW_OIDC_CLIENT_ID` | Client ID |
+| `CW_OIDC_CLIENT_SECRET` | Client secret |
+| `CW_OIDC_PUBLIC_BASE_URL` | External base URL of this instance |
+| `CW_OIDC_GROUPS_CLAIM` | ID token claim holding group membership (default `groups`) |
+| `CW_OIDC_ALLOWED_GROUPS` | Groups allowed to sign in — **empty denies every OIDC login** |
+| `CW_OIDC_SESSION_HOURS` | Lifetime of an OIDC session, 1–168 |
+| `CW_API_KEY` | Static key accepted in the `X-API-Key` header |
+
+Every other setting uses `CW_CFG__` followed by the config path, with `__` between each part:
+
+```yaml
+environment:
+  CW_OIDC_ENABLED: "true"
+  CW_OIDC_ISSUER: "https://auth.example.com/application/o/crosswatch/"
+  CW_OIDC_CLIENT_ID: "crosswatch"
+  CW_OIDC_CLIENT_SECRET: "${CROSSWATCH_OIDC_SECRET}"
+  CW_OIDC_PUBLIC_BASE_URL: "https://crosswatch.example.com"
+  CW_OIDC_ALLOWED_GROUPS: "crosswatch-admins,crosswatch-users"
+  # Any other path:
+  CW_CFG__plex__server_url: "http://plex:32400"
+  CW_CFG__runtime__debug: "true"
+```
+
+Values are read as JSON when they parse as JSON and as plain text otherwise, so `true` is a
+boolean, `12` a number, and `["a","b"]` a list, while a URL is just a string. `CW_OIDC_ALLOWED_GROUPS`
+also accepts a comma-separated list. Setting a variable to an empty string sets the field to
+empty — to hand a field back to `config.json`, remove the variable.
+
+Two limits follow from the `__` path form: list entries cannot be addressed, so sync pairs and
+scrobbler routes are not configurable this way, and keys beginning with an underscore are out of
+reach. Values are read at startup, so changes need a restart.
+
 ## Sponsors
 
 <div align="center">

--- a/api/configAPI.py
+++ b/api/configAPI.py
@@ -14,6 +14,7 @@ from packaging.version import InvalidVersion, Version
 from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi.responses import JSONResponse
 from providers.scrobble.sources import source_enabled
+from cw_platform.config_env import env_locked_paths, env_overrides
 from _logging import log as BASE_LOG
 
 BACKUP_LOG = BASE_LOG.child("BACKUP")
@@ -396,7 +397,35 @@ def api_config() -> JSONResponse:
     if base is None or not hasattr(base, "redact_config"):
         return _nostore(JSONResponse({"ok": False, "error": "Config redaction unavailable"}, status_code=503))
     cfg = base.redact_config(cfg)  # type: ignore[attr-defined]
+    # Tells the UI which fields the environment owns so it can lock them.
+    cfg["_env_locked"] = env_locked_paths()
     return _nostore(JSONResponse(cfg))
+
+
+def _enforce_env_locks(
+    current: dict[str, Any],
+    cfg: dict[str, Any],
+) -> list[str]:
+    """Force env-owned paths back to their effective values; report what changed.
+
+    Runs after sensitive-value preservation so a masked secret the client echoed
+    back is not mistaken for an edit. A locked path is not a client error -- the
+    rest of the save proceeds and the caller is told which fields were dropped.
+    """
+    from cw_platform.config_base import _get_nested_value, _set_nested_value
+
+    ignored: list[str] = []
+    for path in env_overrides():
+        found_cfg, cfg_value = _get_nested_value(cfg, path)
+        if not found_cfg:
+            continue
+        found_cur, cur_value = _get_nested_value(current, path)
+        if found_cfg and found_cur and cfg_value == cur_value:
+            continue
+        ignored.append(".".join(path))
+        if found_cur:
+            _set_nested_value(cfg, path, cur_value)
+    return ignored
 
 def _finalize_config(env: dict[str, Any], cfg: dict[str, Any], *, ensure: bool = False) -> None:
     """Normalize scrobble mode/features.watch, prune+norm pairs, and clear setup-wizard markers.
@@ -542,6 +571,8 @@ def api_config_save(request: Request, payload: dict[str, Any] = Body(...)) -> di
         pass
 
     cfg: dict[str, Any] = dict(merged or {})
+    cfg.pop("_env_locked", None)
+    env_locked_ignored = _enforce_env_locks(current, cfg)
 
     # SSRF guard — reject the save outright for a dangerous server URL
     # (bad scheme, path traversal, or a host that is/resolves to a cloud
@@ -593,6 +624,8 @@ def api_config_save(request: Request, payload: dict[str, Any] = Body(...)) -> di
     _after_config_save(env, cfg)
 
     result: dict[str, Any] = {"ok": True}
+    if env_locked_ignored:
+        result["env_locked_ignored"] = env_locked_ignored
     if watch_runtime_changed:
         try:
             result.update(_apply_watch_runtime(request.app, cfg, watcher_was_running))

--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -2589,3 +2589,8 @@ html[data-cw-theme=flat-light] .cw-page-hero :is(.pp-hero-summary,.wl-hero-summa
 html[data-cw-theme=flat-light] .cw-page-hero :is(.pp-hero-summary,.wl-hero-summary,.ss-hero-summary,.cw-editor-hero-summary)>*{border-color:rgba(78,96,180,.18)!important;color:#172033!important;-webkit-text-fill-color:currentColor!important}
 html[data-cw-theme=flat-light] .cw-page-hero :is(.pp-hero-summary,.wl-hero-summary,.ss-hero-summary,.cw-editor-hero-summary)>:is(button,.pp-btn,.wl-refresh-btn,.ss-hero-refresh,.cw-editor-refresh):hover{background:rgba(17,24,39,.045)!important;background-image:none!important}
 @media(max-width:760px){.cw-page-hero{grid-template-columns:1fr;min-height:0;padding:22px!important}.cw-page-hero::after{right:12px;font-size:112px;opacity:.72}.cw-page-hero-title{font-size:28px!important}.cw-page-hero-actions{justify-content:flex-start!important}}
+
+/* Fields owned by an environment variable: disabled, with the owning var named. */
+.cw-env-locked{opacity:.55;cursor:not-allowed;filter:saturate(.7)}
+.cw-env-chip{display:inline-block;margin:4px 0 0 8px;padding:3px 7px;border-radius:999px;font-size:11px;font-weight:800;letter-spacing:.02em;background:#0b0b16aa;border:1px solid #ffffff2b;color:#cfd6ff;cursor:help;vertical-align:middle}
+html[data-cw-theme=flat-light] .cw-env-chip{background:rgba(17,24,39,.06);border-color:rgba(78,96,180,.28);color:#3b4668}

--- a/assets/helpers/env-lock.js
+++ b/assets/helpers/env-lock.js
@@ -1,0 +1,122 @@
+// Locks config fields the environment owns.
+// The server discards edits to them either way; this makes that visible before
+// the user types instead of after the save silently reverts.
+(function () {
+  const NS = (window.CW ||= {});
+
+  // Mirrors ALIASES in cw_platform/config_env.py; only affects the tooltip text.
+  const ALIASES = {
+    "app_auth.oidc.enabled": "CW_OIDC_ENABLED",
+    "app_auth.oidc.issuer": "CW_OIDC_ISSUER",
+    "app_auth.oidc.client_id": "CW_OIDC_CLIENT_ID",
+    "app_auth.oidc.client_secret": "CW_OIDC_CLIENT_SECRET",
+    "app_auth.oidc.public_base_url": "CW_OIDC_PUBLIC_BASE_URL",
+    "app_auth.oidc.groups_claim": "CW_OIDC_GROUPS_CLAIM",
+    "app_auth.oidc.allowed_groups": "CW_OIDC_ALLOWED_GROUPS",
+    "app_auth.oidc.session_hours": "CW_OIDC_SESSION_HOURS",
+    "security.api_key": "CW_API_KEY",
+  };
+
+  const LOCKED_CLASS = "cw-env-locked";
+  const CHIP_CLASS = "cw-env-chip";
+  const MARKER = "cwEnvLocked";
+
+  let locked = new Set();
+
+  function envVarFor(path) {
+    return ALIASES[path] || "CW_CFG__" + String(path).split(".").join("__");
+  }
+
+  /** Provider credentials live under `<provider>.instances.<name>` unless the
+   *  selected instance is the default one. Mirrors _cwSelectedInst. */
+  function selectedInstance(root) {
+    try {
+      const raw = document.getElementById(`${root}_instance`)?.value;
+      const inst = String(raw || "").trim();
+      return inst || "default";
+    } catch {
+      return "default";
+    }
+  }
+
+  function effectivePath(el) {
+    const path = String(el.getAttribute("data-cfg-path") || "").trim();
+    if (!path) return "";
+    const root = String(el.getAttribute("data-cfg-instance-root") || "").trim();
+    if (!root || !path.startsWith(root + ".")) return path;
+    const inst = selectedInstance(root);
+    if (inst === "default") return path;
+    return `${root}.instances.${inst}.${path.slice(root.length + 1)}`;
+  }
+
+  function addChip(el, path) {
+    if (el.nextElementSibling?.classList?.contains(CHIP_CLASS)) return;
+    const chip = document.createElement("span");
+    chip.className = CHIP_CLASS;
+    chip.textContent = "Set by environment";
+    chip.title = `Set by ${envVarFor(path)}; edits here are ignored.`;
+    el.insertAdjacentElement("afterend", chip);
+  }
+
+  function removeChip(el) {
+    const next = el.nextElementSibling;
+    if (next?.classList?.contains(CHIP_CLASS)) next.remove();
+  }
+
+  function lock(el, path) {
+    if (el.dataset[MARKER] === "1") return;
+    el.dataset[MARKER] = "1";
+    el.disabled = true;
+    el.classList.add(LOCKED_CLASS);
+    addChip(el, path);
+  }
+
+  function unlock(el) {
+    // Only undo what this module did -- other code disables fields for its own
+    // reasons and must keep them disabled.
+    if (el.dataset[MARKER] !== "1") return;
+    delete el.dataset[MARKER];
+    el.disabled = false;
+    el.classList.remove(LOCKED_CLASS);
+    removeChip(el);
+  }
+
+  function apply(cfg) {
+    if (cfg && Array.isArray(cfg._env_locked)) locked = new Set(cfg._env_locked);
+    if (!document.body) return;
+    for (const el of document.querySelectorAll("[data-cfg-path]")) {
+      const path = effectivePath(el);
+      if (path && locked.has(path)) lock(el, path);
+      else unlock(el);
+    }
+  }
+
+  function isLocked(path) {
+    return locked.has(String(path || ""));
+  }
+
+  let pending = 0;
+  function scheduleApply() {
+    if (pending) return;
+    pending = requestAnimationFrame(() => {
+      pending = 0;
+      apply();
+    });
+  }
+
+  function watch() {
+    if (!document.body) return;
+    // Settings panes, provider blocks, and modals all render on demand; watching
+    // is cheaper than hooking every render site and cannot go stale.
+    new MutationObserver(scheduleApply).observe(document.body, { childList: true, subtree: true });
+    document.addEventListener("change", (ev) => {
+      if (/_instance$/.test(String(ev.target?.id || ""))) scheduleApply();
+    });
+    scheduleApply();
+  }
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", watch);
+  else watch();
+
+  NS.EnvLock = { apply, isLocked, envVarFor, scheduleApply };
+})();

--- a/assets/helpers/settings-save.js
+++ b/assets/helpers/settings-save.js
@@ -34,12 +34,22 @@ async function _cwGetConfigFresh() {
   return _cwReadBody(resp);
 }
 
+/** Warn about fields the server refused because the environment owns them.
+ *  Without this the save reports success and the value reverts on reload. */
+function _cwWarnEnvLocked(result) {
+  const paths = result?.env_locked_ignored;
+  if (!Array.isArray(paths) || !paths.length) return result;
+  const names = paths.map((p) => window.CW?.EnvLock?.envVarFor?.(p) || p).join(", ");
+  try { window.CW?.DOM?.showToast?.(`Not saved, set by environment: ${names}`, false); } catch {}
+  return result;
+}
+
 async function _cwSaveConfig(cfg) {
   const api = _cwApi(), out = cfg || {};
-  if (typeof api?.Config?.save === "function") return api.Config.save(out);
+  if (typeof api?.Config?.save === "function") return _cwWarnEnvLocked(await api.Config.save(out));
   const resp = await _cwRequest("/api/config", { method: "POST", headers: _cwJSONHeaders, body: JSON.stringify(out) });
   if (!resp.ok) throw new Error(`POST /api/config ${resp.status}`);
-  return _cwReadBody(resp);
+  return _cwWarnEnvLocked(await _cwReadBody(resp));
 }
 
 function _cwSetConfigCache(cfg) {

--- a/assets/helpers/settings-save.js
+++ b/assets/helpers/settings-save.js
@@ -7,7 +7,7 @@ const _cwSecretIds = [
   "plex_home_pin", "simkl_client_id", "simkl_client_secret",
   "trakt_client_id", "trakt_client_secret", "anilist_client_id", "anilist_client_secret",
   "tmdb_api_key", "tmdb_sync_api_key", "tmdb_sync_session_id", "mdblist_key", "publicmetadb_key", "tautulli_key",
-  "kodi_password"
+  "kodi_password", "app_auth_oidc_client_secret", "security_api_key"
 ];
 
 function _cwEl(id) { return document.getElementById(id); }
@@ -534,6 +534,63 @@ async function saveSettings() {
       }
     } catch (e) {
       console.warn("saveSettings: trusted proxies merge failed", e);
+    }
+
+    try {
+      const prevOidc = serverCfg?.app_auth?.oidc || {};
+      const oidc = {};
+      let oidcChanged = false;
+      const setOidc = (key, next, prev) => {
+        if (next !== prev) { oidc[key] = next; oidcChanged = true; }
+      };
+
+      const enabledEl = _cwEl("app_auth_oidc_enabled");
+      if (enabledEl) setOidc("enabled", _cwTruthy(enabledEl.value), prevOidc.enabled === true);
+
+      [
+        ["app_auth_oidc_issuer", "issuer"],
+        ["app_auth_oidc_client_id", "client_id"],
+        ["app_auth_oidc_public_base_url", "public_base_url"],
+        ["app_auth_oidc_groups_claim", "groups_claim"],
+      ].forEach(([id, key]) => {
+        if (!_cwEl(id)) return;
+        setOidc(key, _getVal(id), _cwNorm(prevOidc[key]));
+      });
+
+      const groupsEl = _cwEl("app_auth_oidc_allowed_groups");
+      if (groupsEl) {
+        const next = String(groupsEl.value || "").split(",").map(_cwNorm).filter(Boolean);
+        const prev = Array.isArray(prevOidc.allowed_groups) ? prevOidc.allowed_groups.map(_cwNorm).filter(Boolean) : [];
+        if (!_cwSameList(next, prev)) { oidc.allowed_groups = next; oidcChanged = true; }
+      }
+
+      const hoursEl = _cwEl("app_auth_oidc_session_hours");
+      if (hoursEl) {
+        const prevHours = Number.isFinite(prevOidc.session_hours) ? Number(prevOidc.session_hours) : 12;
+        const parsed = parseInt(String(hoursEl.value || ""), 10);
+        // The server clamps too; this only avoids sending an obvious typo.
+        const next = Number.isFinite(parsed) ? Math.max(1, Math.min(168, parsed)) : prevHours;
+        setOidc("session_hours", next, prevHours);
+      }
+
+      const secret = _cwReadSecret("app_auth_oidc_client_secret", _cwNorm(prevOidc.client_secret));
+      if (secret.changed) {
+        _cwApplySecret(oidc, "client_secret", secret, "");
+        oidcChanged = true;
+      }
+      if (oidcChanged) {
+        ensureObj(ensureObj(cfg, "app_auth"), "oidc");
+        Object.assign(cfg.app_auth.oidc, oidc);
+        mark();
+      }
+
+      const apiKey = _cwReadSecret("security_api_key", _cwNorm(serverCfg?.security?.api_key));
+      if (apiKey.changed) {
+        _cwApplySecret(ensureObj(cfg, "security"), "api_key", apiKey, "");
+        mark();
+      }
+    } catch (e) {
+      console.warn("saveSettings: oidc merge failed", e);
     }
 
     const prevMode = serverCfg?.sync?.bidirectional?.mode || "two-way";

--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -1477,6 +1477,40 @@ async function loadConfig() {
     const aaP2 = document.getElementById("app_auth_password2");
     if (aaP2) aaP2.value = "";
 
+    {
+      const oidc = aa.oidc || {};
+      const setText = (id, value) => {
+        const el = document.getElementById(id);
+        if (el) el.value = value;
+      };
+      _setSelectValue("app_auth_oidc_enabled", oidc.enabled === true ? "true" : "false");
+      setText("app_auth_oidc_issuer", typeof oidc.issuer === "string" ? oidc.issuer : "");
+      setText("app_auth_oidc_client_id", typeof oidc.client_id === "string" ? oidc.client_id : "");
+      setText("app_auth_oidc_public_base_url", typeof oidc.public_base_url === "string" ? oidc.public_base_url : "");
+      setText("app_auth_oidc_groups_claim", typeof oidc.groups_claim === "string" ? oidc.groups_claim : "");
+      setText(
+        "app_auth_oidc_allowed_groups",
+        Array.isArray(oidc.allowed_groups) ? oidc.allowed_groups.join(", ") : ""
+      );
+      setText(
+        "app_auth_oidc_session_hours",
+        String(Number.isFinite(oidc.session_hours) ? oidc.session_hours : 12)
+      );
+
+      // Secrets arrive redacted; keep them masked so an untouched field is
+      // never written back as the redaction placeholder.
+      const shared = window.CW?.AuthShared;
+      [
+        ["app_auth_oidc_client_secret", oidc.client_secret],
+        ["security_api_key", cfg.security?.api_key],
+      ].forEach(([id, value]) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        shared?.maskSecret?.(el, !!String(value || "").trim());
+        shared?.wireSecretInput?.(el);
+      });
+    }
+
     // Trusted reverse proxies (optional)
     const tpEl = _cwTrustedProxiesEl();
     if (tpEl) {

--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -1326,6 +1326,7 @@ async function loadConfig() {
   if (!r.ok) throw new Error(`GET /api/config ${r.status}`);
   const cfg = await r.json();
   window._cfgCache = cfg;
+  try { window.CW?.EnvLock?.apply?.(cfg); } catch {}
 
   const _refreshSelectUi = (el) => {
     if (!el) return;

--- a/assets/js/modals/tls/index.js
+++ b/assets/js/modals/tls/index.js
@@ -271,7 +271,7 @@ export default {
             <div class="grid2">
               <div class="field">
                 <label for="tls-mode">Mode</label>
-                <select id="tls-mode">
+                <select id="tls-mode" data-cfg-path="ui.tls.self_signed">
                   <option value="self">Self-signed (generated)</option>
                   <option value="custom">Custom cert/key paths</option>
                 </select>
@@ -280,33 +280,33 @@ export default {
 
               <div class="field">
                 <label for="tls-hostname">Hostname (CN)</label>
-                <input id="tls-hostname" type="text" value="localhost" />
+                <input id="tls-hostname" data-cfg-path="ui.tls.hostname" type="text" value="localhost" />
                 <div class="hint">Used for the self-signed certificate CN and included in SAN.</div>
               </div>
 
               <div class="field">
                 <label for="tls-days">Valid days</label>
-                <input id="tls-days" type="number" min="1" max="3650" value="825" />
+                <input id="tls-days" data-cfg-path="ui.tls.valid_days" type="number" min="1" max="3650" value="825" />
               </div>
 
               <div class="field">
                 <label for="tls-altdns">Additional DNS names (comma separated)</label>
-                <input id="tls-altdns" type="text" placeholder="mybox.local, crosswatch.local" />
+                <input id="tls-altdns" data-cfg-path="ui.tls.alt_dns" type="text" placeholder="mybox.local, crosswatch.local" />
               </div>
 
               <div class="field">
                 <label for="tls-altips">Additional IPs (comma separated)</label>
-                <input id="tls-altips" type="text" placeholder="192.168.1.10" />
+                <input id="tls-altips" data-cfg-path="ui.tls.alt_ips" type="text" placeholder="192.168.1.10" />
               </div>
 
               <div class="field">
                 <label for="tls-certfile">Cert file path</label>
-                <input id="tls-certfile" type="text" placeholder="/config/tls/crosswatch.crt" />
+                <input id="tls-certfile" data-cfg-path="ui.tls.cert_file" type="text" placeholder="/config/tls/crosswatch.crt" />
               </div>
 
               <div class="field">
                 <label for="tls-keyfile">Key file path</label>
-                <input id="tls-keyfile" type="text" placeholder="/config/tls/crosswatch.key" />
+                <input id="tls-keyfile" data-cfg-path="ui.tls.key_file" type="text" placeholder="/config/tls/crosswatch.key" />
               </div>
             </div>
 

--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -158,7 +158,7 @@ html[data-cw-theme=flat-dark] .pp-settings-dialog.cw-insight-set{background:#171
                         <span class="setting-name">Slow provider timeout</span>
                         <span class="setting-copy">Seconds</span>
                       </span>
-                      <input id="pp-settings-timeout" type="number" min="3" max="60" step="1">
+                      <input id="pp-settings-timeout" data-cfg-path="playback_progress.provider_timeout_seconds" type="number" min="3" max="60" step="1">
                     </label>
                   </div>
                 </div>

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -15,6 +15,8 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, cast
 
+from .config_env import apply_env_overrides, env_overrides
+
 
 def _current_version_norm() -> str:
     try:
@@ -967,6 +969,20 @@ def _get_nested_value(src: dict[str, Any], path: str | Iterable[str]) -> tuple[b
     return True, cur
 
 
+def _delete_nested_value(dst: dict[str, Any], path: str | Iterable[str]) -> None:
+    parts = _path_parts(path)
+    if not parts:
+        return
+
+    cur: Any = dst
+    for part in parts[:-1]:
+        if not isinstance(cur, dict) or part not in cur:
+            return
+        cur = cur[part]
+    if isinstance(cur, dict):
+        cur.pop(parts[-1], None)
+
+
 def _set_nested_value(dst: dict[str, Any], path: str | Iterable[str], value: Any) -> None:
     parts = _path_parts(path)
     if not parts:
@@ -1659,7 +1675,13 @@ def _normalize_app_auth(cfg: dict[str, Any]) -> None:
     oidc["public_base_url"] = str(oidc.get("public_base_url", "") or "").strip().rstrip("/")
     oidc["groups_claim"] = str(oidc.get("groups_claim", "groups") or "").strip() or "groups"
     raw_groups = oidc.get("allowed_groups")
-    items = raw_groups if isinstance(raw_groups, list) else ([raw_groups] if raw_groups else [])
+    if isinstance(raw_groups, list):
+        items: list[Any] = raw_groups
+    elif raw_groups:
+        # A single env var can only carry a string, so accept a comma-separated list.
+        items = str(raw_groups).split(",")
+    else:
+        items = []
     oidc["allowed_groups"] = [s for s in (str(x or "").strip() for x in items) if s]
     try:
         hours = int(oidc.get("session_hours", 12) or 12)
@@ -1741,6 +1763,27 @@ def _ensure_webhook_ids(cfg: dict[str, Any]) -> tuple[dict[str, Any], bool]:
 
     return cfg, changed
 
+_ENV_LOCKS_LOGGED = False
+
+
+def _log_env_locks(applied: list[tuple[str, ...]]) -> None:
+    """Announce env-owned paths once; load_config runs on nearly every request.
+
+    Paths only -- the values are frequently secrets.
+    """
+    global _ENV_LOCKS_LOGGED
+    if _ENV_LOCKS_LOGGED or not applied:
+        return
+    _ENV_LOCKS_LOGGED = True
+    names = ", ".join(sorted(".".join(p) for p in applied))
+    try:
+        from _logging import log as _real_log
+
+        _real_log(f"Config locked by environment: {names}", level="INFO", module="CONFIG")
+    except Exception:
+        print(f"[CONFIG] INFO: Config locked by environment: {names}")
+
+
 def load_config() -> dict[str, Any]:
     p = _cfg_file()
     first_run = not p.exists()
@@ -1752,6 +1795,8 @@ def load_config() -> dict[str, Any]:
             raise RuntimeError(f"Invalid config file: {p}") from e
 
     cfg = _deep_merge(DEFAULT_CFG, user_cfg)
+    # Before the normalizers, so env values get the same clamping as file values.
+    _log_env_locks(apply_env_overrides(cfg))
     cfg.setdefault("version", _current_version_norm())
     _normalize_tmdb_sync(cfg)
     _normalize_trakt(cfg)
@@ -1793,8 +1838,29 @@ def load_config() -> dict[str, Any]:
     return cfg
 
 
+def _revert_env_paths(payload: dict[str, Any], prev_raw: dict[str, Any]) -> None:
+    """Undo env-owned values so they never reach config.json.
+
+    Restores whatever the file held, or drops the key when the file never had
+    one; unsetting the variable then reveals the file value again, unchanged.
+
+    Runs on the encrypted write payload rather than on the caller's config:
+    that tree is freshly built by _encrypt_secret_tree_stable, so mutating it
+    cannot corrupt a config dict the caller still holds, and prev_raw's values
+    are already in on-disk form.
+    """
+    for path in env_overrides():
+        found, prev_value = _get_nested_value(prev_raw, path)
+        if found:
+            _set_nested_value(payload, path, prev_value)
+        else:
+            _delete_nested_value(payload, path)
+
+
 def save_config(cfg: dict[str, Any]) -> None:
     data: dict[str, Any] = dict(cfg or {})
+    # UI round-trips the GET /api/config response, which carries this marker.
+    data.pop("_env_locked", None)
     prev_version = str(data.get("version") or "").strip()
     try:
         ui0 = data.get("ui")
@@ -1830,4 +1896,6 @@ def save_config(cfg: dict[str, Any]) -> None:
     except Exception:
         prev_raw = {}
 
-    _write_json_atomic(_cfg_file(), cast(dict[str, Any], _encrypt_secret_tree_stable(data, prev_raw)))
+    payload = cast(dict[str, Any], _encrypt_secret_tree_stable(data, prev_raw))
+    _revert_env_paths(payload, prev_raw)
+    _write_json_atomic(_cfg_file(), payload)

--- a/cw_platform/config_env.py
+++ b/cw_platform/config_env.py
@@ -1,0 +1,129 @@
+# cw_platform/config_env.py
+# Environment-variable overrides for config paths.
+# Deliberately free of config_base imports: config_base imports this module.
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from typing import Any
+
+GENERIC_PREFIX = "CW_CFG__"
+
+# Short names for the settings a container deployment most often injects.
+# Anything not listed here is still reachable through GENERIC_PREFIX.
+ALIASES: dict[str, tuple[str, ...]] = {
+    "CW_OIDC_ENABLED": ("app_auth", "oidc", "enabled"),
+    "CW_OIDC_ISSUER": ("app_auth", "oidc", "issuer"),
+    "CW_OIDC_CLIENT_ID": ("app_auth", "oidc", "client_id"),
+    "CW_OIDC_CLIENT_SECRET": ("app_auth", "oidc", "client_secret"),
+    "CW_OIDC_PUBLIC_BASE_URL": ("app_auth", "oidc", "public_base_url"),
+    "CW_OIDC_GROUPS_CLAIM": ("app_auth", "oidc", "groups_claim"),
+    "CW_OIDC_ALLOWED_GROUPS": ("app_auth", "oidc", "allowed_groups"),
+    "CW_OIDC_SESSION_HOURS": ("app_auth", "oidc", "session_hours"),
+    "CW_API_KEY": ("security", "api_key"),
+}
+
+_PATH_TO_ALIAS: dict[tuple[str, ...], str] = {path: name for name, path in ALIASES.items()}
+
+
+def _log(msg: str, *, level: str = "INFO") -> None:
+    try:
+        from _logging import log as _real_log
+
+        _real_log(msg, level=level, module="CONFIG")
+    except Exception:
+        print(f"[CONFIG] {level}: {msg}")
+
+
+def _parse_value(raw: str) -> Any:
+    """JSON first so bools, numbers, and lists survive; bare strings fall through.
+
+    Most values (URLs, client ids, claim names) are not valid JSON, so the
+    fallback is the common case rather than an error path.
+    """
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return raw
+
+
+def _generic_path(name: str) -> tuple[str, ...] | None:
+    rest = name[len(GENERIC_PREFIX):]
+    parts = tuple(p.lower() for p in rest.split("__") if p)
+    return parts or None
+
+
+def env_overrides(environ: Mapping[str, str] | None = None) -> dict[tuple[str, ...], Any]:
+    """Config paths the environment owns, mapped to their parsed values.
+
+    An empty variable is an override to the empty value, not an absence -- unset
+    the variable to hand the field back to config.json.
+    """
+    src = os.environ if environ is None else environ
+    out: dict[tuple[str, ...], Any] = {}
+    generic_names: dict[tuple[str, ...], str] = {}
+
+    for name, raw in src.items():
+        if not name.startswith(GENERIC_PREFIX):
+            continue
+        path = _generic_path(name)
+        if path is None:
+            continue
+        out[path] = _parse_value(raw)
+        generic_names[path] = name
+
+    for name, path in ALIASES.items():
+        raw = src.get(name)
+        if raw is None:
+            continue
+        if path in generic_names:
+            _log(
+                f"{name} and {generic_names[path]} both set {'.'.join(path)}; using {name}",
+                level="WARNING",
+            )
+        out[path] = _parse_value(raw)
+
+    return out
+
+
+def env_locked_paths(environ: Mapping[str, str] | None = None) -> list[str]:
+    """Dotted paths the environment owns, for the UI lock and the API response."""
+    return sorted(".".join(path) for path in env_overrides(environ))
+
+
+def env_var_for_path(path: tuple[str, ...] | str) -> str:
+    """The variable name that owns a path, for user-facing messages."""
+    parts = tuple(path.split(".")) if isinstance(path, str) else tuple(path)
+    alias = _PATH_TO_ALIAS.get(parts)
+    return alias if alias else GENERIC_PREFIX + "__".join(parts)
+
+
+def _set_path(cfg: dict[str, Any], path: tuple[str, ...], value: Any) -> bool:
+    cur: Any = cfg
+    for part in path[:-1]:
+        nxt = cur.get(part)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            cur[part] = nxt
+        cur = nxt
+    if not isinstance(cur, dict):
+        return False
+    cur[path[-1]] = value
+    return True
+
+
+def apply_env_overrides(
+    cfg: dict[str, Any],
+    environ: Mapping[str, str] | None = None,
+) -> list[tuple[str, ...]]:
+    """Write env-owned values into cfg in place; returns the paths applied.
+
+    Called before the normalizers so env values get the same clamping and
+    coercion as file values.
+    """
+    applied: list[tuple[str, ...]] = []
+    for path, value in env_overrides(environ).items():
+        if _set_path(cfg, path, value):
+            applied.append(path)
+    return applied

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,16 @@ services:
       - "${CROSSWATCH_PORT:-8787}:8787"
     environment:
       TZ: "${TZ:-Europe/Amsterdam}"
+      # Any setting can come from the environment instead of config.json; these
+      # values win and are never written to the config volume. See the README
+      # for the CW_CFG__<path> form that reaches every other setting.
+      # CW_OIDC_ENABLED: "true"
+      # CW_OIDC_ISSUER: "https://auth.example.com/application/o/crosswatch/"
+      # CW_OIDC_CLIENT_ID: "crosswatch"
+      # CW_OIDC_CLIENT_SECRET: "${CROSSWATCH_OIDC_SECRET}"
+      # CW_OIDC_PUBLIC_BASE_URL: "https://crosswatch.example.com"
+      # CW_OIDC_ALLOWED_GROUPS: "crosswatch-admins"
+      # CW_API_KEY: "${CROSSWATCH_API_KEY}"
     volumes:
       - crosswatch_config:/config
     restart: unless-stopped

--- a/docs/superpowers/specs/2026-07-31-oidc-env-vars-design.md
+++ b/docs/superpowers/specs/2026-07-31-oidc-env-vars-design.md
@@ -297,6 +297,15 @@ empty value is a deny rather than a default.
   listed in `tests/data/env_lock_exclusions.txt`. Fails when a new config field ships without an
   annotation or an explicit exclusion.
 
+**`tests/test_env_lock_js.py`** — runs `env-lock.js` under node against a stub DOM: locked
+fields disable and get the right variable name, unlocked fields are untouched, and a provider
+path resolves under the selected instance. A wrong resolution here fails open, so it needs
+direct coverage rather than inference from the markup.
+
+**`tests/test_oidc_settings_ui.py`** — every OIDC field renders, is annotated, is collected on
+save, and is hydrated on load; secrets are password inputs; the empty-allowed-groups denial is
+stated in the UI.
+
 **`tests/test_oidc_config.py`** — extended for the comma-split `allowed_groups` case.
 
 Existing suite must stay green; note the 6 pre-existing failures on `main` are unrelated.

--- a/docs/superpowers/specs/2026-07-31-oidc-env-vars-design.md
+++ b/docs/superpowers/specs/2026-07-31-oidc-env-vars-design.md
@@ -118,8 +118,11 @@ A module-level flag guards the log, since `load_config()` runs on nearly every r
 
 ### 3. Write path — `config_base.save_config`
 
-After the `_normalize_*` calls and before `_encrypt_secret_tree_stable`, every env-managed path
-is reverted in the write payload:
+Every env-managed path is reverted in the write payload, on the tree returned by
+`_encrypt_secret_tree_stable` rather than on `data`. `save_config` only shallow-copies its
+argument, so reverting on `data` reaches into nested dicts the caller still holds — and
+`load_config` calls `save_config` on first run, which would delete the value it had just applied.
+The encrypted tree is freshly built, and `prev_raw`'s values are already in on-disk form:
 
 - If the path exists in `prev_raw` (the on-disk JSON, already read by `save_config`), restore
   that value verbatim.
@@ -127,10 +130,6 @@ is reverted in the write payload:
 
 A new `_delete_nested_value(dst, path)` helper is needed; it prunes only the leaf, leaving
 parent dicts in place.
-
-Restoring an encrypted `enc:v1:` string verbatim is safe: `_encrypt_secret_tree_stable` will try
-`_decrypt_secret(prev) == obj`, fail the comparison, and call `_encrypt_secret(obj)` — which
-short-circuits on the `_ENC_PREFIX` and returns the string unchanged. No double encryption.
 
 Net effect: `config.json` is byte-identical at env-managed paths across saves, and unsetting the
 env var reverts the field to whatever the file said all along.

--- a/docs/superpowers/specs/2026-07-31-oidc-env-vars-design.md
+++ b/docs/superpowers/specs/2026-07-31-oidc-env-vars-design.md
@@ -1,0 +1,342 @@
+# Environment-variable configuration for OIDC (and any config path)
+
+Date: 2026-07-31
+Status: Approved
+
+## Problem
+
+`app_auth.oidc.*` and `security.api_key` can only be set by editing `config.json`. In a
+container deployment the natural source for those values — especially `client_secret` and
+`api_key` — is the environment (Docker `environment:`, a Kubernetes Secret, a GitOps-managed
+manifest). Today an operator has to bake secrets into a mounted `config.json` and keep it out
+of version control by hand.
+
+Two further problems fall out of adding env support:
+
+1. `save_config` writes the whole config back to disk. An env-injected secret would be
+   persisted into `config.json` on the next save, defeating the point.
+2. The UI edits config fields freely. If an env var owns a field, a UI edit appears to save
+   and then silently reverts on the next load.
+
+## Goals
+
+- Set any `app_auth.oidc.*` field and `security.api_key` from the environment.
+- Set any other config path from the environment via a generic escape hatch.
+- Env-injected values never land in `config.json`.
+- The UI shows env-owned fields as locked, and a save that discards an env-owned change says so.
+- OIDC becomes configurable from the UI at all (it has no settings pane today).
+
+## Non-goals
+
+- Reloading config when the environment changes at runtime. Env is read per `load_config()`
+  call; a container restart is the update mechanism, consistent with "config changes require
+  restart" in CLAUDE.md.
+- Addressing list elements (`pairs[0]`, scrobbler routes) from the environment. See Limitations.
+- Any change to how secrets are encrypted at rest.
+
+## Design
+
+### 1. `cw_platform/config_env.py` (new)
+
+A standalone module with no `config_base` import, so there is no import cycle — `config_base`
+imports it, not the reverse.
+
+```python
+def env_overrides(environ: Mapping[str, str] | None = None) -> dict[tuple[str, ...], Any]
+def apply_env_overrides(cfg: dict[str, Any], environ: Mapping[str, str] | None = None) -> list[tuple[str, ...]]
+def env_locked_paths(environ: Mapping[str, str] | None = None) -> list[str]
+def env_var_for_path(path: tuple[str, ...] | str) -> str
+```
+
+`environ` is injectable so tests never mutate `os.environ`.
+
+**Source A — explicit aliases.** A literal table:
+
+| Env var | Config path |
+|---|---|
+| `CW_OIDC_ENABLED` | `app_auth.oidc.enabled` |
+| `CW_OIDC_ISSUER` | `app_auth.oidc.issuer` |
+| `CW_OIDC_CLIENT_ID` | `app_auth.oidc.client_id` |
+| `CW_OIDC_CLIENT_SECRET` | `app_auth.oidc.client_secret` |
+| `CW_OIDC_PUBLIC_BASE_URL` | `app_auth.oidc.public_base_url` |
+| `CW_OIDC_GROUPS_CLAIM` | `app_auth.oidc.groups_claim` |
+| `CW_OIDC_ALLOWED_GROUPS` | `app_auth.oidc.allowed_groups` |
+| `CW_OIDC_SESSION_HOURS` | `app_auth.oidc.session_hours` |
+| `CW_API_KEY` | `security.api_key` |
+
+**Source B — generic.** `CW_CFG__<part>__<part>__…`: strip the prefix, split on `__`,
+lowercase each part. `CW_CFG__app_auth__oidc__issuer` → `("app_auth", "oidc", "issuer")`.
+Empty parts (from `___` or a trailing `__`) are dropped; a name that yields no parts is ignored.
+
+An alias and a generic var naming the same path is a conflict; the alias wins and the collision
+is logged at WARNING.
+
+**Value parsing.** `json.loads(raw)`; on `json.JSONDecodeError` use `raw` verbatim as a string.
+So:
+
+| Env value | Parsed |
+|---|---|
+| `true` | `True` |
+| `12` | `12` |
+| `["admins","ops"]` | `["admins", "ops"]` |
+| `https://auth.example.com/o/cw/` | `"https://auth.example.com/o/cw/"` |
+| `admins,ops` | `"admins,ops"` (then comma-split by normalization, see §2) |
+
+An empty env var (`CW_OIDC_ISSUER=`) parses to `""` and **is** an override — it locks the field
+to empty rather than being treated as unset. Unset the variable to release the field.
+
+`env_var_for_path` inverts the mapping for UI messaging: an aliased path returns its alias,
+anything else returns the `CW_CFG__…` form.
+
+### 2. Read path — `config_base.load_config`
+
+`apply_env_overrides(cfg)` is called immediately after `_deep_merge(DEFAULT_CFG, user_cfg)` and
+**before** the `_normalize_*` calls. Env values therefore go through exactly the same validation
+and clamping as file values — no second code path:
+
+- `CW_OIDC_SESSION_HOURS=9999` → clamped to `168`
+- `CW_OIDC_ISSUER=" https://… "` → whitespace stripped, trailing slash preserved
+- `CW_OIDC_PUBLIC_BASE_URL=https://cw.example.com/` → trailing slash dropped
+- `CW_OIDC_GROUPS_CLAIM=` → falls back to `"groups"`
+
+Values are written with the existing `_set_nested_value`, which creates intermediate dicts as
+needed — so `CW_API_KEY` works even though `security.api_key` has no `DEFAULT_CFG` entry.
+
+**One normalization change.** `_normalize_app_auth` currently wraps a bare-string
+`allowed_groups` as a single-element list, so `CW_OIDC_ALLOWED_GROUPS=admins,ops` would become
+`["admins,ops"]`. Change it to split a string value on commas and strip each part. The JSON list
+form keeps working; an existing single-value string config is unaffected (a comma in an OIDC
+group name is not a real case).
+
+The applied paths are logged once per process at INFO, listing paths only — never values:
+
+```
+[CONFIG] INFO: Config locked by environment: app_auth.oidc.issuer, app_auth.oidc.client_secret, security.api_key
+```
+
+A module-level flag guards the log, since `load_config()` runs on nearly every request.
+
+### 3. Write path — `config_base.save_config`
+
+After the `_normalize_*` calls and before `_encrypt_secret_tree_stable`, every env-managed path
+is reverted in the write payload:
+
+- If the path exists in `prev_raw` (the on-disk JSON, already read by `save_config`), restore
+  that value verbatim.
+- Otherwise delete the key from the payload.
+
+A new `_delete_nested_value(dst, path)` helper is needed; it prunes only the leaf, leaving
+parent dicts in place.
+
+Restoring an encrypted `enc:v1:` string verbatim is safe: `_encrypt_secret_tree_stable` will try
+`_decrypt_secret(prev) == obj`, fail the comparison, and call `_encrypt_secret(obj)` — which
+short-circuits on the `_ENC_PREFIX` and returns the string unchanged. No double encryption.
+
+Net effect: `config.json` is byte-identical at env-managed paths across saves, and unsetting the
+env var reverts the field to whatever the file said all along.
+
+`save_config` also pops a top-level `_env_locked` key defensively, since `POST /api/config`
+deep-merges the client payload into the current config and the UI receives that key.
+
+### 4. API — `api/configAPI.py`
+
+**`GET /api/config`** adds a top-level `_env_locked` array of dotted paths, injected after
+`redact_config`:
+
+```json
+{ "app_auth": { … }, "_env_locked": ["app_auth.oidc.issuer", "app_auth.oidc.client_secret"] }
+```
+
+Secret values at those paths stay redacted as they are today; only the path list is new.
+
+**`POST /api/config`** compares the incoming payload against the env-locked paths. Any locked
+path present in the payload with a value differing from the effective config is dropped from the
+merge and reported:
+
+```json
+{ "ok": true, "env_locked_ignored": ["app_auth.oidc.issuer"] }
+```
+
+The save still succeeds for everything else — a locked field is not an error, it is not the
+client's to set.
+
+**Other config-writing endpoints.** `POST /api/config` is not the only writer —
+`/api/playback_progress/settings`, `/api/scrobbler/routes`, the anime-mapping endpoints, and the
+OIDC callback all call `save_config` directly. The never-persisted guarantee lives in
+`save_config` itself, so it holds for all of them without further change. Only the
+`env_locked_ignored` *reporting* is specific to `POST /api/config`; the other endpoints silently
+discard locked paths, which is acceptable because the fields they own are either not lockable
+(list-indexed) or covered by the UI lock.
+
+### 5. Frontend — lock mechanism
+
+**`assets/helpers/env-lock.js` (new).** Exports `window.CW.applyEnvLocks(cfg)`:
+
+1. Read `cfg._env_locked` (cached alongside the existing config cache).
+2. For each element carrying `data-cfg-path`, resolve its effective path (see instance handling
+   below) and test membership.
+3. On a match: set `disabled`, add class `cw-env-locked`, and insert a "Set by environment" chip
+   after the field with `title="Set by <ENV_VAR>"`. The env var name comes from a small
+   client-side copy of the alias table, falling back to the `CW_CFG__` form.
+4. On no match: remove the class, chip, and the `disabled` this function set — tracked with a
+   `data-cfg-env-locked` marker so the function never re-enables a field some other code
+   disabled for its own reasons.
+
+Idempotent and safe to re-run. Called after every config hydration and after each settings pane
+or modal render.
+
+**Instance-scoped provider fields.** Provider credentials live under `plex.server_url` for the
+default instance and `plex.instances.<name>.server_url` otherwise (see `_cwEnsureInstBlock` in
+`settings-save.js`). Those inputs carry both attributes:
+
+```html
+<input id="plex_server_url" data-cfg-path="plex.server_url" data-cfg-instance-root="plex">
+```
+
+`applyEnvLocks` rewrites the path to `plex.instances.<selected>.server_url` when the selected
+instance is not `default`, reading the selection the same way `_cwSelectedInst` does. It re-runs
+on instance change.
+
+**Annotation pass.** `data-cfg-path` is added to every config-bound input, select, and textarea:
+
+| File | Fields |
+|---|---|
+| `ui_frontend.py` | `app_auth_*`, `ui_*`, `debug`, `trusted_proxies`, `sch*` (scheduling), `cw_*` (CrossWatch tracker) |
+| `providers/auth/_auth_PLEX.py` | 10 |
+| `providers/auth/_auth_JELLYFIN.py` | 12 |
+| `providers/auth/_auth_EMBY.py` | 12 |
+| `providers/auth/_auth_KODI.py` | 8 |
+| `providers/auth/_auth_SIMKL.py` | 4 |
+| `providers/auth/_auth_MDBLIST.py` | 3 |
+| `providers/auth/_auth_TRAKT.py` | 3 |
+| `providers/auth/_auth_TAUTULLI.py` | 3 |
+| `providers/auth/_auth_ANILIST.py` | 2 |
+| `providers/auth/_auth_TMDB.py` | 2 |
+| `providers/auth/_auth_NUVIO.py` | 2 |
+| `providers/auth/_auth_PUBLICMETADB.py` | 1 |
+| `assets/js/modals/tls/index.js` | 7 (`ui.tls.*`) |
+| `assets/js/playback_progress.js` | 1 (`pp-settings-timeout` → `playback_progress.provider_timeout_seconds`) |
+
+Each path is verified against the field's actual write site in `settings-save.js` or the modal's
+own save function — the element id is not a reliable guide (`app_auth_remember_enabled` writes
+`app_auth.remember_session_enabled`).
+
+**Explicitly out of scope, by construction:**
+
+- `assets/js/modals/pair-config/index.js` (112 elements) — writes `pairs[i].*`. List indices are
+  unaddressable from the environment, so these can never be locked.
+- `assets/js/modals/scrobbler-route/index.js`, `scrobbler-webhook/index.js` — route records
+  posted to `/api/scrobbler/routes`, keyed by id in a list. Same reason.
+- Filter, search, and picker inputs that never touch config: `playlists.js`, `snapshots.js`,
+  `watchlist.js`, `activity.js`, `editor.js`, `exporter`, `maintenance`, `manual-watched`,
+  `analyzer`, `provider-cleanup`, `insight-settings`, `capture-compare`, `events`,
+  the `pp-*` filter controls in `playback_progress.js`, `source-provider` /
+  `target-provider` in `ui_frontend.py`.
+- View-state toggles that gate other fields without being config themselves:
+  `schEnabledToggle` and `schAdvEnabled` in `scheduler.js`.
+
+These are recorded in `tests/data/env_lock_exclusions.txt` so the coverage test (§7) can tell
+"deliberately not config-bound" from "someone forgot".
+
+**Discarded-save feedback.** The `POST /api/config` caller in `settings-save.js` reads
+`env_locked_ignored` and raises a toast naming the fields, so a save that silently dropped a
+change now says which one and why.
+
+**CSS.** `.cw-env-locked` and `.cw-env-chip` in `assets/crosswatch.css`, following the existing
+disabled-field styling.
+
+### 6. Frontend — OIDC settings section
+
+OIDC has no UI today, so locking it would be theoretical. The app_auth settings pane in
+`ui_frontend.py` gains an "Single sign-on (OIDC)" block:
+
+| Field | Path | Control |
+|---|---|---|
+| Enable OIDC | `app_auth.oidc.enabled` | select true/false, matching `app_auth_remember_enabled` |
+| Issuer URL | `app_auth.oidc.issuer` | text |
+| Client ID | `app_auth.oidc.client_id` | text |
+| Client secret | `app_auth.oidc.client_secret` | password, masked |
+| Public base URL | `app_auth.oidc.public_base_url` | text |
+| Groups claim | `app_auth.oidc.groups_claim` | text, placeholder `groups` |
+| Allowed groups | `app_auth.oidc.allowed_groups` | text, comma-separated |
+| Session hours | `app_auth.oidc.session_hours` | number, 1–168 |
+| API key | `security.api_key` | password, masked |
+
+Hydration goes in `settings-ui.js` beside the existing `app_auth` block; collection goes in
+`settings-save.js`. Both secrets use the existing mask sentinel and `_cwApplySecret` convention,
+so an untouched masked field is never written back as the literal mask. Empty `allowed_groups`
+denies every OIDC login — the field carries that as help text, since it is the one setting whose
+empty value is a deny rather than a default.
+
+### 7. Tests
+
+**`tests/test_config_env.py`**
+- Value parsing per type: bool, int, JSON list, bare string, empty string.
+- Alias form and generic form both resolve to the right path.
+- Alias wins over a conflicting generic var.
+- Malformed generic names (`CW_CFG__`, `CW_CFG____`) are ignored, not crashes.
+- `env_var_for_path` returns the alias for aliased paths, `CW_CFG__…` otherwise.
+
+**`tests/test_config_env_integration.py`**
+- Env value beats a conflicting `config.json` value.
+- Env value is still normalized: `session_hours=9999` → `168`, issuer whitespace stripped.
+- `allowed_groups=admins,ops` → `["admins", "ops"]`; JSON list form also works.
+- `save_config` leaves an env-managed path byte-identical in `config.json`, including the
+  encrypted `client_secret` case.
+- `save_config` deletes the key when the path was absent on disk.
+- Unsetting the env var restores the file value on the next load.
+- `_env_locked` is stripped on save.
+
+**`tests/test_config_api_env_lock.py`**
+- `_env_locked` present and correct in `GET /api/config`.
+- `POST /api/config` reports `env_locked_ignored` and does not persist the locked change.
+- A non-locked field in the same payload still saves.
+
+**`tests/test_env_lock_coverage.py`**
+- Regex-scans `ui_frontend.py`, `providers/auth/_auth_*.py`, and the annotated JS files for
+  `<input|select|textarea …>` and asserts each element id either carries `data-cfg-path` or is
+  listed in `tests/data/env_lock_exclusions.txt`. Fails when a new config field ships without an
+  annotation or an explicit exclusion.
+
+**`tests/test_oidc_config.py`** — extended for the comma-split `allowed_groups` case.
+
+Existing suite must stay green; note the 6 pre-existing failures on `main` are unrelated.
+
+### 8. Documentation
+
+`README.md` gains an "Environment variables" section: the alias table, the `CW_CFG__` form and
+its JSON-then-string rule, the never-persisted guarantee, and the limitations below. The
+`docker-compose.yml` example gains commented-out OIDC variables.
+
+## Limitations
+
+- **No list indices.** `CW_CFG__pairs__0__enabled` does not work; `_set_nested_value` builds
+  dicts only. Sync pairs and scrobbler routes are not env-configurable.
+- **No leading-underscore keys.** Splitting on `__` cannot express `ui._autogen`. These are
+  internal markers, not user settings.
+- **Case.** Path parts are lowercased. Every current config key is lowercase snake_case; a
+  mixed-case key added later would be unreachable generically and would need an alias.
+- **Restart to change.** Env is read per `load_config()`, but the app caches config in places
+  and CLAUDE.md already requires a restart for config changes.
+
+## Risks
+
+- **Generic override reaches secrets.** By design — that is the point for `client_secret` and
+  provider tokens. Mitigated by never persisting them and by never logging values.
+- **A stale `data-cfg-path` silently stops locking a field.** The coverage test catches a
+  *missing* annotation but not a *wrong* one. Mitigated by verifying each path against its write
+  site during the annotation pass, and by the server-side `env_locked_ignored` response, which is
+  correct regardless of what the UI believes.
+- **Empty-string override semantics.** `CW_OIDC_ISSUER=` locks the field to empty rather than
+  releasing it. Documented in the README; the alternative (treat empty as unset) makes it
+  impossible to deliberately blank a field from the environment.
+
+## Alternatives considered
+
+- **Env seeds `config.json` on first run.** Rejected: bakes secrets into the file, and removing
+  the env var leaves a stale value behind — bad for GitOps.
+- **Env only fills empty values.** Rejected: makes the environment non-authoritative, so a
+  GitOps-managed deployment cannot be sure what it is running.
+- **Central path→selector registry in JS instead of `data-cfg-path`.** Rejected: a registry
+  drifts the moment someone adds a field, and nothing fails when it does. The attribute lives
+  with the field and is statically checkable.

--- a/providers/auth/_auth_ANILIST.py
+++ b/providers/auth/_auth_ANILIST.py
@@ -208,11 +208,11 @@ def html() -> str:
             <div class="grid2">
                   <div>
                     <label for="anilist_client_id">Client ID</label>
-                    <input id="anilist_client_id" name="anilist_client_id" placeholder="Your AniList client_id" autocomplete="off" />
+                    <input id="anilist_client_id" data-cfg-path="anilist.client_id" data-cfg-instance-root="anilist" name="anilist_client_id" placeholder="Your AniList client_id" autocomplete="off" />
                   </div>
                   <div>
                     <label for="anilist_client_secret">Client Secret</label>
-                    <input id="anilist_client_secret" name="anilist_client_secret" placeholder="Your AniList client_secret" type="password" autocomplete="off" />
+                    <input id="anilist_client_secret" data-cfg-path="anilist.client_secret" data-cfg-instance-root="anilist" name="anilist_client_secret" placeholder="Your AniList client_secret" type="password" autocomplete="off" />
                   </div>
                 </div>
             

--- a/providers/auth/_auth_EMBY.py
+++ b/providers/auth/_auth_EMBY.py
@@ -284,15 +284,15 @@ def html() -> str:
               <div style="grid-column:1 / -1">
                 <label for="emby_server">Server URL</label>
                 <div class="inp-row">
-                  <input id="emby_server" name="emby_server" class="grow" placeholder="http://host:8096/">
-                  <label class="verify"><input id="emby_verify_ssl" type="checkbox"> Verify SSL</label>
+                  <input id="emby_server" data-cfg-path="emby.server" data-cfg-instance-root="emby" name="emby_server" class="grow" placeholder="http://host:8096/">
+                  <label class="verify"><input id="emby_verify_ssl" data-cfg-path="emby.verify_ssl" data-cfg-instance-root="emby" type="checkbox"> Verify SSL</label>
                 </div>
               </div>
             </div>
             <div class="grid2" style="margin-top:8px">
               <div>
                 <label for="emby_user">Username</label>
-                <input id="emby_user" name="emby_user" placeholder="username">
+                <input id="emby_user" data-cfg-path="emby.username" data-cfg-instance-root="emby" name="emby_user" placeholder="username">
               </div>
               <div>
                 <label for="emby_pass">Password</label>
@@ -310,17 +310,17 @@ def html() -> str:
             <div style="max-width:820px">
               <label for="emby_server_url">Server URL</label>
               <div class="inp-row">
-                <input id="emby_server_url" name="emby_server_url" class="grow" placeholder="http://host:8096/">
-                <label class="verify"><input id="emby_verify_ssl_dup" type="checkbox"> Verify SSL</label>
+                <input id="emby_server_url" data-cfg-path="emby.server" data-cfg-instance-root="emby" name="emby_server_url" class="grow" placeholder="http://host:8096/">
+                <label class="verify"><input id="emby_verify_ssl_dup" data-cfg-path="emby.verify_ssl" data-cfg-instance-root="emby" type="checkbox"> Verify SSL</label>
               </div>
               <div class="sub">Leave blank to discover.</div>
 
               <label for="emby_username" style="margin-top:10px">Username</label>
-              <input id="emby_username" name="emby_username" placeholder="Display name">
+              <input id="emby_username" data-cfg-path="emby.username" data-cfg-instance-root="emby" name="emby_username" placeholder="Display name">
 
               <label for="emby_user_id" style="margin-top:10px">User_ID</label>
               <div class="inp-row">
-                <input id="emby_user_id" name="emby_user_id" class="grow" placeholder="e.g. 6f7a0b3b-... (GUID)">
+                <input id="emby_user_id" data-cfg-path="emby.user_id" data-cfg-instance-root="emby" name="emby_user_id" class="grow" placeholder="e.g. 6f7a0b3b-... (GUID)">
                 <button id="emby_pick_user" class="cw-userpick-icon material-symbols-rounded" type="button" data-cw-emby="pick-user" title="Pick user" aria-label="Pick user">person_search</button>
               </div>
               <div class="sub">Uses your signed-in account. Admin accounts show all users; otherwise you'll only see yourself.</div>
@@ -335,10 +335,10 @@ def html() -> str:
           <div class="cw-subpanel" data-sub="whitelist">
             <div style="max-width:980px">
               <div id="emby_lib_matrix"></div>
-              <select id="emby_lib_history" class="lm-hidden" multiple></select>
-              <select id="emby_lib_ratings" class="lm-hidden" multiple></select>
-              <select id="emby_lib_progress" class="lm-hidden" multiple></select>
-              <select id="emby_lib_scrobble" class="lm-hidden" multiple></select>
+              <select id="emby_lib_history" data-cfg-path="emby.history.libraries" data-cfg-instance-root="emby" class="lm-hidden" multiple></select>
+              <select id="emby_lib_ratings" data-cfg-path="emby.ratings.libraries" data-cfg-instance-root="emby" class="lm-hidden" multiple></select>
+              <select id="emby_lib_progress" data-cfg-path="emby.progress.libraries" data-cfg-instance-root="emby" class="lm-hidden" multiple></select>
+              <select id="emby_lib_scrobble" data-cfg-path="emby.scrobble.libraries" data-cfg-instance-root="emby" class="lm-hidden" multiple></select>
             </div>
           </div>
         </div>

--- a/providers/auth/_auth_JELLYFIN.py
+++ b/providers/auth/_auth_JELLYFIN.py
@@ -404,8 +404,8 @@ def html() -> str:
               <div style="grid-column:1 / -1">
                 <label for="jfy_server">Server URL</label>
                 <div class="inp-row">
-                  <input id="jfy_server" name="jfy_server" class="grow" placeholder="http://host:8096/">
-                  <label class="verify"><input id="jfy_verify_ssl" type="checkbox"> Verify SSL</label>
+                  <input id="jfy_server" data-cfg-path="jellyfin.server" data-cfg-instance-root="jellyfin" name="jfy_server" class="grow" placeholder="http://host:8096/">
+                  <label class="verify"><input id="jfy_verify_ssl" data-cfg-path="jellyfin.verify_ssl" data-cfg-instance-root="jellyfin" type="checkbox"> Verify SSL</label>
                 </div>
               </div>
             </div>
@@ -440,7 +440,7 @@ def html() -> str:
               <div class="grid2" style="margin-top:4px">
                 <div>
                   <label for="jfy_user">Username</label>
-                  <input id="jfy_user" name="jfy_user" placeholder="username" autocomplete="username">
+                  <input id="jfy_user" data-cfg-path="jellyfin.username" data-cfg-instance-root="jellyfin" name="jfy_user" placeholder="username" autocomplete="username">
                 </div>
                 <div>
                   <label for="jfy_pass">Password</label>
@@ -468,17 +468,17 @@ def html() -> str:
             <div style="max-width:820px">
               <label for="jfy_server_url">Server URL</label>
               <div class="inp-row">
-                <input id="jfy_server_url" name="jfy_server_url" class="grow" placeholder="http://host:8096/">
-                <label class="verify"><input id="jfy_verify_ssl_dup" type="checkbox"> Verify SSL</label>
+                <input id="jfy_server_url" data-cfg-path="jellyfin.server" data-cfg-instance-root="jellyfin" name="jfy_server_url" class="grow" placeholder="http://host:8096/">
+                <label class="verify"><input id="jfy_verify_ssl_dup" data-cfg-path="jellyfin.verify_ssl" data-cfg-instance-root="jellyfin" type="checkbox"> Verify SSL</label>
               </div>
               <div class="sub">Leave blank to discover.</div>
 
               <label for="jfy_username" style="margin-top:10px">Username</label>
-              <input id="jfy_username" name="jfy_username" placeholder="Display name">
+              <input id="jfy_username" data-cfg-path="jellyfin.username" data-cfg-instance-root="jellyfin" name="jfy_username" placeholder="Display name">
 
               <label for="jfy_user_id" style="margin-top:10px">User_ID</label>
               <div class="inp-row">
-                <input id="jfy_user_id" name="jfy_user_id" class="grow" placeholder="e.g. 6f7a0b3b-... (GUID)">
+                <input id="jfy_user_id" data-cfg-path="jellyfin.user_id" data-cfg-instance-root="jellyfin" name="jfy_user_id" class="grow" placeholder="e.g. 6f7a0b3b-... (GUID)">
                 <button id="jfy_pick_user" class="cw-userpick-icon material-symbols-rounded" type="button" title="Pick user" aria-label="Pick user">person_search</button>
               </div>
               <div class="sub">Uses your signed-in account. Admin accounts show all users; otherwise you'll only see yourself.</div>
@@ -493,10 +493,10 @@ def html() -> str:
           <div class="cw-subpanel" data-sub="whitelist">
             <div style="max-width:980px">
               <div id="jfy_lib_matrix"></div>
-              <select id="jfy_lib_history" name="jfy_lib_history" class="lm-hidden" multiple></select>
-              <select id="jfy_lib_ratings" name="jfy_lib_ratings" class="lm-hidden" multiple></select>
-              <select id="jfy_lib_progress" name="jfy_lib_progress" class="lm-hidden" multiple></select>
-              <select id="jfy_lib_scrobble" name="jfy_lib_scrobble" class="lm-hidden" multiple></select>
+              <select id="jfy_lib_history" data-cfg-path="jellyfin.history.libraries" data-cfg-instance-root="jellyfin" name="jfy_lib_history" class="lm-hidden" multiple></select>
+              <select id="jfy_lib_ratings" data-cfg-path="jellyfin.ratings.libraries" data-cfg-instance-root="jellyfin" name="jfy_lib_ratings" class="lm-hidden" multiple></select>
+              <select id="jfy_lib_progress" data-cfg-path="jellyfin.progress.libraries" data-cfg-instance-root="jellyfin" name="jfy_lib_progress" class="lm-hidden" multiple></select>
+              <select id="jfy_lib_scrobble" data-cfg-path="jellyfin.scrobble.libraries" data-cfg-instance-root="jellyfin" name="jfy_lib_scrobble" class="lm-hidden" multiple></select>
             </div>
           </div>
         </div>

--- a/providers/auth/_auth_KODI.py
+++ b/providers/auth/_auth_KODI.py
@@ -387,17 +387,17 @@ def html() -> str:
               <div style="grid-column:1 / -1">
                 <label for="kodi_server">Server URL</label>
                 <div class="inp-row">
-                  <input id="kodi_server" name="kodi_server" class="grow" placeholder="http://host:8080">
-                  <label class="verify"><input id="kodi_verify_ssl" type="checkbox"> Verify SSL</label>
+                  <input id="kodi_server" data-cfg-path="kodi.server" data-cfg-instance-root="kodi" name="kodi_server" class="grow" placeholder="http://host:8080">
+                  <label class="verify"><input id="kodi_verify_ssl" data-cfg-path="kodi.verify_ssl" data-cfg-instance-root="kodi" type="checkbox"> Verify SSL</label>
                 </div>
               </div>
               <div>
                 <label for="kodi_username">Username</label>
-                <input id="kodi_username" name="kodi_username" autocomplete="username" placeholder="optional">
+                <input id="kodi_username" data-cfg-path="kodi.username" data-cfg-instance-root="kodi" name="kodi_username" autocomplete="username" placeholder="optional">
               </div>
               <div>
                 <label for="kodi_password">Password</label>
-                <input id="kodi_password" name="kodi_password" type="password" autocomplete="current-password" placeholder="optional">
+                <input id="kodi_password" data-cfg-path="kodi.password" data-cfg-instance-root="kodi" name="kodi_password" type="password" autocomplete="current-password" placeholder="optional">
               </div>
             </div>
 
@@ -419,10 +419,10 @@ def html() -> str:
                 </div>
               </div>
             </div>
-            <select id="kodi_lib_history" class="lm-hidden" multiple></select>
-            <select id="kodi_lib_ratings" class="lm-hidden" multiple></select>
-            <select id="kodi_lib_progress" class="lm-hidden" multiple></select>
-            <select id="kodi_lib_scrobble" class="lm-hidden" multiple></select>
+            <select id="kodi_lib_history" data-cfg-path="kodi.history.libraries" data-cfg-instance-root="kodi" class="lm-hidden" multiple></select>
+            <select id="kodi_lib_ratings" data-cfg-path="kodi.ratings.libraries" data-cfg-instance-root="kodi" class="lm-hidden" multiple></select>
+            <select id="kodi_lib_progress" data-cfg-path="kodi.progress.libraries" data-cfg-instance-root="kodi" class="lm-hidden" multiple></select>
+            <select id="kodi_lib_scrobble" data-cfg-path="kodi.scrobble.libraries" data-cfg-instance-root="kodi" class="lm-hidden" multiple></select>
           </div>
         </div>
       </div>

--- a/providers/auth/_auth_MDBLIST.py
+++ b/providers/auth/_auth_MDBLIST.py
@@ -265,7 +265,7 @@ def html() -> str:
                 <button id="mdblist_disconnect_api" class="btn danger">Delete</button>
               </div>
             </div>
-            <input id="mdblist_auth_method" name="mdblist_auth_method" type="hidden" value="device_code">
+            <input id="mdblist_auth_method" data-cfg-path="mdblist.auth_method" data-cfg-instance-root="mdblist" name="mdblist_auth_method" type="hidden" value="device_code">
 
             <div id="mdblist_device_panel" class="mdbl-pane" data-method="device_code">
               <input id="mdblist_device_code" type="hidden">
@@ -289,7 +289,7 @@ def html() -> str:
                 <div>
                   <label for="mdblist_key">API Key</label>
                   <div class="mdbl-api-field-row">
-                    <input id="mdblist_key" name="mdblist_key" type="password" placeholder="********" />
+                    <input id="mdblist_key" data-cfg-path="mdblist.api_key" data-cfg-instance-root="mdblist" name="mdblist_key" type="password" placeholder="********" />
                     <div id="mdblist_hint" class="msg warn">
                       Create API key at
                       <a href="https://mdblist.com/preferences/#api" target="_blank" rel="noopener">MDBList Preferences</a>.

--- a/providers/auth/_auth_NUVIO.py
+++ b/providers/auth/_auth_NUVIO.py
@@ -864,7 +864,7 @@ def html() -> str:
             <div id="nuvio_profile_state" class="nuvio-profile-row hidden">
               <div>
                 <label for="nuvio_profile_select">Nuvio profile</label>
-                <select id="nuvio_profile_select"></select>
+                <select id="nuvio_profile_select" data-cfg-path="nuvio.profile_id" data-cfg-instance-root="nuvio"></select>
               </div>
             </div>
             <div id="nuvio_login_state" class="nuvio-qc hidden">

--- a/providers/auth/_auth_PLEX.py
+++ b/providers/auth/_auth_PLEX.py
@@ -345,10 +345,10 @@ def html() -> str:
             <div style="max-width:820px">
               <label for="plex_server_url">Server URL</label>
               <div class="fieldline">
-                <input id="plex_server_url" name="plex_server_url" placeholder="http://host:32400" list="plex_server_suggestions">
+                <input id="plex_server_url" data-cfg-path="plex.server_url" data-cfg-instance-root="plex" name="plex_server_url" placeholder="http://host:32400" list="plex_server_suggestions">
                 <datalist id="plex_server_suggestions"></datalist>
                 <label class="sslopt" title="Verify server TLS certificate">
-                  <input type="checkbox" id="plex_verify_ssl">
+                  <input type="checkbox" id="plex_verify_ssl" data-cfg-path="plex.verify_ssl" data-cfg-instance-root="plex">
                   <span class="lbl">Verify SSL</span>
                 </label>
               </div>
@@ -356,15 +356,15 @@ def html() -> str:
 
               <label for="plex_username" style="margin-top:10px">Username</label>
               <div class="fieldline userpick">
-                <input id="plex_username" name="plex_username" placeholder="Plex Home profile">
+                <input id="plex_username" data-cfg-path="plex.username" data-cfg-instance-root="plex" name="plex_username" placeholder="Plex Home profile">
                 <button class="cw-userpick-icon material-symbols-rounded" id="plex_user_pick_btn" type="button" title="Choose from server users" aria-label="Choose from server users">person_search</button>
               </div>
 
               <label for="plex_account_id" style="margin-top:10px">Account_ID</label>
-              <input id="plex_account_id" name="plex_account_id" type="number" min="1" placeholder="e.g. 1">
+              <input id="plex_account_id" data-cfg-path="plex.account_id" data-cfg-instance-root="plex" name="plex_account_id" type="number" min="1" placeholder="e.g. 1">
 
               <label for="plex_home_pin" style="margin-top:10px">Home PIN (optional)</label>
-              <input id="plex_home_pin" name="plex_home_pin" type="password" inputmode="numeric" autocomplete="new-password" placeholder="4 digits">
+              <input id="plex_home_pin" data-cfg-path="plex.home_pin" data-cfg-instance-root="plex" name="plex_home_pin" type="password" inputmode="numeric" autocomplete="new-password" placeholder="4 digits">
               <div class="sub">Only needed if the selected Plex Home user is PIN-protected.</div>
 
               <div class="plex-btnrow">
@@ -377,10 +377,10 @@ def html() -> str:
           <div class="cw-subpanel" data-sub="whitelist">
             <div style="max-width:980px">
               <div id="plex_lib_matrix"></div>
-              <select id="plex_lib_history" class="lm-hidden" multiple></select>
-              <select id="plex_lib_ratings" class="lm-hidden" multiple></select>
-              <select id="plex_lib_progress" class="lm-hidden" multiple></select>
-              <select id="plex_lib_scrobble" class="lm-hidden" multiple></select>
+              <select id="plex_lib_history" data-cfg-path="plex.history.libraries" data-cfg-instance-root="plex" class="lm-hidden" multiple></select>
+              <select id="plex_lib_ratings" data-cfg-path="plex.ratings.libraries" data-cfg-instance-root="plex" class="lm-hidden" multiple></select>
+              <select id="plex_lib_progress" data-cfg-path="plex.progress.libraries" data-cfg-instance-root="plex" class="lm-hidden" multiple></select>
+              <select id="plex_lib_scrobble" data-cfg-path="plex.scrobble.libraries" data-cfg-instance-root="plex" class="lm-hidden" multiple></select>
             </div>
           </div>
         </div>

--- a/providers/auth/_auth_PUBLICMETADB.py
+++ b/providers/auth/_auth_PUBLICMETADB.py
@@ -188,7 +188,7 @@ def html() -> str:
             <div class="grid2">
               <div>
                 <label for="publicmetadb_key">API Key</label>
-                <input id="publicmetadb_key" name="publicmetadb_key" type="password" placeholder="pm-..." />
+                <input id="publicmetadb_key" data-cfg-path="publicmetadb.api_key" data-cfg-instance-root="publicmetadb" name="publicmetadb_key" type="password" placeholder="pm-..." />
               </div>
             </div>
 

--- a/providers/auth/_auth_SIMKL.py
+++ b/providers/auth/_auth_SIMKL.py
@@ -455,7 +455,7 @@ def html() -> str:
                 <span id="simkl-countdown" style="min-width:60px;"></span>
               </div>
             </div>
-            <input id="simkl_auth_method" name="simkl_auth_method" type="hidden" value="pin">
+            <input id="simkl_auth_method" data-cfg-path="simkl.auth_method" data-cfg-instance-root="simkl" name="simkl_auth_method" type="hidden" value="pin">
 
             <div id="simkl_pin_panel" class="smk-pane" data-method="pin">
               <input id="simkl_pin_code" type="hidden">
@@ -478,11 +478,11 @@ def html() -> str:
               <div class="grid2">
                 <div>
                   <label for="simkl_client_id">Client ID</label>
-                  <input id="simkl_client_id" name="simkl_client_id" placeholder="Your SIMKL client id">
+                  <input id="simkl_client_id" data-cfg-path="simkl.client_id" data-cfg-instance-root="simkl" name="simkl_client_id" placeholder="Your SIMKL client id">
                 </div>
                 <div>
                   <label for="simkl_client_secret">Client Secret</label>
-                  <input id="simkl_client_secret" name="simkl_client_secret" placeholder="Your SIMKL client secret" type="password">
+                  <input id="simkl_client_secret" data-cfg-path="simkl.client_secret" data-cfg-instance-root="simkl" name="simkl_client_secret" placeholder="Your SIMKL client secret" type="password">
                 </div>
               </div>
 

--- a/providers/auth/_auth_TAUTULLI.py
+++ b/providers/auth/_auth_TAUTULLI.py
@@ -224,17 +224,17 @@ def html() -> str:
             <div class="grid2">
               <div>
                 <label for="tautulli_server">Server URL</label>
-                <input id="tautulli_server" name="tautulli_server" type="text" placeholder="http://localhost:8181" />
+                <input id="tautulli_server" data-cfg-path="tautulli.server_url" data-cfg-instance-root="tautulli" name="tautulli_server" type="text" placeholder="http://localhost:8181" />
               </div>
               <div>
                 <label for="tautulli_key">API Key</label>
-                <input id="tautulli_key" name="tautulli_key" type="password" placeholder="********" />
+                <input id="tautulli_key" data-cfg-path="tautulli.api_key" data-cfg-instance-root="tautulli" name="tautulli_key" type="password" placeholder="********" />
               </div>
             </div>
 
             <div style="margin-top:10px;max-width:240px">
               <label for="tautulli_user_id">User ID (optional)<span class="cw-help" title="If this is empty, CrossWatch imports history for all Tautulli users. Normally you only want one user ID.">?</span></label>
-              <input id="tautulli_user_id" name="tautulli_user_id" type="text" placeholder="1" />
+              <input id="tautulli_user_id" data-cfg-path="tautulli.history.user_id" data-cfg-instance-root="tautulli" name="tautulli_user_id" type="text" placeholder="1" />
             </div>
 
             <div id="tautulli_hint" class="msg warn" style="margin-top:10px">

--- a/providers/auth/_auth_TMDB.py
+++ b/providers/auth/_auth_TMDB.py
@@ -186,7 +186,7 @@ def _tmdb_sync_html() -> str:
                 <div class="grid2">
                   <div>
                     <label for="tmdb_sync_api_key">API Key (v3)</label>
-                    <input id="tmdb_sync_api_key" name="tmdb_sync_api_key" type="password" autocomplete="new-password" placeholder="Enter TMDb API key" spellcheck="false" autocapitalize="off" />
+                    <input id="tmdb_sync_api_key" data-cfg-path="tmdb_sync.api_key" data-cfg-instance-root="tmdb_sync" name="tmdb_sync_api_key" type="password" autocomplete="new-password" placeholder="Enter TMDb API key" spellcheck="false" autocapitalize="off" />
                     <div id="tmdb_sync_hint" class="msg warn" style="margin-top:8px">
                       Create one at
                       <a href="https://www.themoviedb.org/settings/api" target="_blank" rel="noopener">TMDb Preferences</a>
@@ -195,7 +195,7 @@ def _tmdb_sync_html() -> str:
             
                   <div>
                     <label for="tmdb_sync_session_id">Session ID (v3)</label>
-                    <input id="tmdb_sync_session_id" name="tmdb_sync_session_id" type="password" autocomplete="off" placeholder="Created after approval" readonly aria-readonly="true" tabindex="-1" />
+                    <input id="tmdb_sync_session_id" data-cfg-path="tmdb_sync.session_id" data-cfg-instance-root="tmdb_sync" name="tmdb_sync_session_id" type="password" autocomplete="off" placeholder="Created after approval" readonly aria-readonly="true" tabindex="-1" />
                     
                   </div>
                 </div>

--- a/providers/auth/_auth_TRAKT.py
+++ b/providers/auth/_auth_TRAKT.py
@@ -247,11 +247,11 @@ class _TraktProvider:
             <div class="grid2">
               <div>
                 <label for="trakt_client_id">Client ID</label>
-                <input id="trakt_client_id" name="trakt_client_id" placeholder="Enter your Trakt Client ID">
+                <input id="trakt_client_id" data-cfg-path="trakt.client_id" data-cfg-instance-root="trakt" name="trakt_client_id" placeholder="Enter your Trakt Client ID">
               </div>
               <div>
                 <label for="trakt_client_secret">Client Secret</label>
-                <input id="trakt_client_secret" name="trakt_client_secret" type="password" placeholder="Enter your Trakt Client Secret">
+                <input id="trakt_client_secret" data-cfg-path="trakt.client_secret" data-cfg-instance-root="trakt" name="trakt_client_secret" type="password" placeholder="Enter your Trakt Client Secret">
               </div>
             </div>
 

--- a/tests/data/env_lock_exclusions.txt
+++ b/tests/data/env_lock_exclusions.txt
@@ -1,0 +1,33 @@
+# Form elements in the env-lock scan set that are deliberately not config-bound.
+# A new field must either carry data-cfg-path or be listed here with a reason,
+# so an unlockable setting cannot ship by accident.
+#
+# Format: <file>:<element id>
+
+# Sync pair pickers, not settings.
+ui_frontend.py:source-provider
+ui_frontend.py:target-provider
+
+# Filter and search controls over already-loaded data.
+assets/js/playback_progress.js:pp-search
+assets/js/playback_progress.js:pp-provider
+assets/js/playback_progress.js:pp-type
+assets/js/playback_progress.js:pp-progress
+assets/js/playback_progress.js:pp-progress-range
+assets/js/playback_progress.js:pp-progress-value
+assets/js/playback_progress.js:pp-age
+assets/js/playback_progress.js:pp-rating
+assets/js/playback_progress.js:pp-sort
+# Hidden per-row carrier for provider/instance attributes.
+assets/js/playback_progress.js:(no id)
+
+# Login credentials posted to a connect endpoint; never stored in config.
+providers/auth/_auth_EMBY.py:emby_pass
+providers/auth/_auth_JELLYFIN.py:jfy_pass
+
+# Transient codes for device/PIN authorization flows.
+providers/auth/_auth_PLEX.py:plex_pin
+providers/auth/_auth_SIMKL.py:simkl_pin_code
+providers/auth/_auth_TRAKT.py:trakt_pin
+providers/auth/_auth_MDBLIST.py:mdblist_device_code
+providers/auth/_auth_NUVIO.py:nuvio_code_input

--- a/tests/data/env_lock_harness.js
+++ b/tests/data/env_lock_harness.js
@@ -1,0 +1,76 @@
+// Minimal DOM stub for exercising assets/helpers/env-lock.js under node.
+// Only the handful of APIs env-lock.js touches are implemented.
+const fs = require("fs");
+
+function makeEl(attrs) {
+  const el = {
+    attrs: { ...attrs },
+    dataset: {},
+    classes: new Set(),
+    disabled: false,
+    nextElementSibling: null,
+    getAttribute: (k) => (k in el.attrs ? el.attrs[k] : null),
+    classList: {
+      add: (c) => el.classes.add(c),
+      remove: (c) => el.classes.delete(c),
+      contains: (c) => el.classes.has(c),
+    },
+    insertAdjacentElement: (_pos, node) => {
+      node.nextElementSibling = el.nextElementSibling;
+      el.nextElementSibling = node;
+    },
+    remove: () => {},
+  };
+  return el;
+}
+
+const elements = [];
+const byId = {};
+
+global.requestAnimationFrame = (fn) => fn();
+global.window = {};
+global.document = {
+  readyState: "complete",
+  body: {},
+  addEventListener: () => {},
+  getElementById: (id) => byId[id] || null,
+  querySelectorAll: () => elements,
+  createElement: () => {
+    const node = makeEl({});
+    node.classList = {
+      add: (c) => node.classes.add(c),
+      remove: (c) => node.classes.delete(c),
+      contains: (c) => node.classes.has(c),
+    };
+    return node;
+  },
+};
+global.MutationObserver = class {
+  observe() {}
+};
+
+const spec = JSON.parse(process.argv[2]);
+for (const item of spec.elements) {
+  const el = makeEl(item.attrs);
+  el.id = item.id;
+  elements.push(el);
+  if (item.id) byId[item.id] = el;
+}
+for (const [id, value] of Object.entries(spec.instances || {})) {
+  byId[id] = { value };
+}
+
+eval(fs.readFileSync(spec.source, "utf8"));
+
+window.CW.EnvLock.apply({ _env_locked: spec.locked });
+
+console.log(
+  JSON.stringify(
+    elements.map((el) => ({
+      id: el.id,
+      disabled: el.disabled,
+      locked: el.classes.has("cw-env-locked"),
+      chip: el.nextElementSibling ? el.nextElementSibling.title : null,
+    }))
+  )
+);

--- a/tests/test_config_api_env_lock.py
+++ b/tests/test_config_api_env_lock.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _stub_env(monkeypatch, cfg_api, load_cfg, save_cfg) -> None:
+    from cw_platform import config_base
+
+    monkeypatch.setattr(
+        cfg_api,
+        "_env",
+        lambda: {
+            "CW": None,
+            "cfg_base": config_base,
+            "load": load_cfg,
+            "save": save_cfg,
+            "prune": lambda *_: None,
+            "ensure": lambda *_: None,
+            "norm_pair": lambda *_: None,
+            "probes_cache": None,
+            "probes_status_cache": None,
+            "scheduler": None,
+        },
+    )
+
+
+def _stub_request():
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+
+
+def test_get_config_reports_env_locked_paths(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from api import configAPI as cfg_api
+    from cw_platform.config_base import load_config, save_config
+
+    monkeypatch.setenv("CW_OIDC_ISSUER", "https://from-env.example.com/")
+    monkeypatch.setenv("CW_API_KEY", "machine-key")
+    _stub_env(monkeypatch, cfg_api, load_config, save_config)
+
+    body = json.loads(cfg_api.api_config().body)
+    assert body["_env_locked"] == ["app_auth.oidc.issuer", "security.api_key"]
+
+
+def test_get_config_omits_marker_content_when_no_env(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from api import configAPI as cfg_api
+    from cw_platform.config_base import load_config, save_config
+
+    _stub_env(monkeypatch, cfg_api, load_config, save_config)
+    assert json.loads(cfg_api.api_config().body)["_env_locked"] == []
+
+
+def test_save_reports_and_discards_locked_change(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from api import configAPI as cfg_api
+    from cw_platform.config_base import load_config, save_config
+
+    monkeypatch.setenv("CW_OIDC_ISSUER", "https://from-env.example.com/")
+    _stub_env(monkeypatch, cfg_api, load_config, save_config)
+
+    result = cfg_api.api_config_save(
+        _stub_request(), {"app_auth": {"oidc": {"issuer": "https://from-ui.example.com/"}}}
+    )
+    assert result["env_locked_ignored"] == ["app_auth.oidc.issuer"]
+    assert load_config()["app_auth"]["oidc"]["issuer"] == "https://from-env.example.com/"
+    stored = json.loads((config_base / "config.json").read_text(encoding="utf-8"))
+    assert "issuer" not in stored.get("app_auth", {}).get("oidc", {})
+
+
+def test_save_keeps_unlocked_fields_from_same_payload(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from api import configAPI as cfg_api
+    from cw_platform.config_base import load_config, save_config
+
+    monkeypatch.setenv("CW_OIDC_ISSUER", "https://from-env.example.com/")
+    _stub_env(monkeypatch, cfg_api, load_config, save_config)
+
+    result = cfg_api.api_config_save(
+        _stub_request(),
+        {
+            "app_auth": {
+                "oidc": {"issuer": "https://from-ui.example.com/", "client_id": "cw-ui"}
+            }
+        },
+    )
+    assert result["env_locked_ignored"] == ["app_auth.oidc.issuer"]
+    assert load_config()["app_auth"]["oidc"]["client_id"] == "cw-ui"
+
+
+def test_save_without_locked_change_reports_nothing(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from api import configAPI as cfg_api
+    from cw_platform.config_base import load_config, save_config
+
+    monkeypatch.setenv("CW_OIDC_ISSUER", "https://from-env.example.com/")
+    _stub_env(monkeypatch, cfg_api, load_config, save_config)
+
+    result = cfg_api.api_config_save(_stub_request(), {"app_auth": {"oidc": {"client_id": "cw-ui"}}})
+    assert "env_locked_ignored" not in result
+
+
+def test_echoing_the_get_response_back_is_not_an_edit(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A masked secret round-tripped by the UI must not read as a change."""
+    from api import configAPI as cfg_api
+    from cw_platform.config_base import load_config, save_config
+
+    monkeypatch.setenv("CW_OIDC_CLIENT_SECRET", "env-secret")
+    _stub_env(monkeypatch, cfg_api, load_config, save_config)
+
+    body = json.loads(cfg_api.api_config().body)
+    result = cfg_api.api_config_save(_stub_request(), body)
+    assert "env_locked_ignored" not in result

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+
+from cw_platform.config_env import (
+    apply_env_overrides,
+    env_locked_paths,
+    env_overrides,
+    env_var_for_path,
+)
+
+
+def test_alias_resolves_to_path() -> None:
+    got = env_overrides({"CW_OIDC_ISSUER": "https://auth.example.com/o/cw/"})
+    assert got == {("app_auth", "oidc", "issuer"): "https://auth.example.com/o/cw/"}
+
+
+def test_generic_form_resolves_to_path() -> None:
+    got = env_overrides({"CW_CFG__plex__server_url": "http://plex:32400"})
+    assert got == {("plex", "server_url"): "http://plex:32400"}
+
+
+def test_generic_form_lowercases_parts() -> None:
+    got = env_overrides({"CW_CFG__PLEX__SERVER_URL": "http://plex:32400"})
+    assert ("plex", "server_url") in got
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("true", True),
+        ("false", False),
+        ("12", 12),
+        ('["admins","ops"]', ["admins", "ops"]),
+        ("https://auth.example.com/o/cw/", "https://auth.example.com/o/cw/"),
+        ("admins,ops", "admins,ops"),
+        ("", ""),
+    ],
+)
+def test_value_parsing(raw: str, expected: object) -> None:
+    got = env_overrides({"CW_CFG__a__b": raw})
+    assert got[("a", "b")] == expected
+
+
+def test_empty_value_is_an_override_not_an_absence() -> None:
+    assert ("app_auth", "oidc", "issuer") in env_overrides({"CW_OIDC_ISSUER": ""})
+
+
+def test_alias_wins_over_conflicting_generic() -> None:
+    got = env_overrides(
+        {
+            "CW_OIDC_ISSUER": "https://alias.example.com/",
+            "CW_CFG__app_auth__oidc__issuer": "https://generic.example.com/",
+        }
+    )
+    assert got[("app_auth", "oidc", "issuer")] == "https://alias.example.com/"
+
+
+@pytest.mark.parametrize("name", ["CW_CFG__", "CW_CFG____", "CW_CFG"])
+def test_malformed_generic_names_are_ignored(name: str) -> None:
+    assert env_overrides({name: "x"}) == {}
+
+
+def test_unrelated_vars_are_ignored() -> None:
+    assert env_overrides({"PATH": "/usr/bin", "CONFIG_BASE": "/config"}) == {}
+
+
+def test_env_locked_paths_are_dotted_and_sorted() -> None:
+    got = env_locked_paths({"CW_OIDC_ISSUER": "x", "CW_API_KEY": "y"})
+    assert got == ["app_auth.oidc.issuer", "security.api_key"]
+
+
+def test_env_var_for_path_prefers_alias() -> None:
+    assert env_var_for_path("app_auth.oidc.client_secret") == "CW_OIDC_CLIENT_SECRET"
+    assert env_var_for_path(("security", "api_key")) == "CW_API_KEY"
+
+
+def test_env_var_for_path_falls_back_to_generic() -> None:
+    assert env_var_for_path("plex.server_url") == "CW_CFG__plex__server_url"
+
+
+def test_apply_writes_values_and_reports_paths() -> None:
+    cfg: dict[str, object] = {"app_auth": {"oidc": {"issuer": "from-file"}}}
+    applied = apply_env_overrides(cfg, {"CW_OIDC_ISSUER": "from-env"})
+    assert applied == [("app_auth", "oidc", "issuer")]
+    assert cfg["app_auth"]["oidc"]["issuer"] == "from-env"  # type: ignore[index]
+
+
+def test_apply_creates_missing_intermediate_dicts() -> None:
+    cfg: dict[str, object] = {}
+    apply_env_overrides(cfg, {"CW_API_KEY": "machine-key"})
+    assert cfg == {"security": {"api_key": "machine-key"}}
+
+
+def test_apply_replaces_non_dict_intermediate() -> None:
+    cfg: dict[str, object] = {"security": "not-a-dict"}
+    apply_env_overrides(cfg, {"CW_API_KEY": "machine-key"})
+    assert cfg == {"security": {"api_key": "machine-key"}}

--- a/tests/test_config_env_integration.py
+++ b/tests/test_config_env_integration.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _write_cfg(config_base: Path, payload: dict) -> None:
+    (config_base / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _raw_cfg(config_base: Path) -> dict:
+    return json.loads((config_base / "config.json").read_text(encoding="utf-8"))
+
+
+def test_env_beats_config_file(config_base: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from cw_platform.config_base import load_config
+
+    _write_cfg(config_base, {"app_auth": {"oidc": {"issuer": "https://from-file.example.com/"}}})
+    monkeypatch.setenv("CW_OIDC_ISSUER", "https://from-env.example.com/")
+    assert load_config()["app_auth"]["oidc"]["issuer"] == "https://from-env.example.com/"
+
+
+def test_env_values_are_still_normalized(config_base: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from cw_platform.config_base import load_config
+
+    monkeypatch.setenv("CW_OIDC_SESSION_HOURS", "9999")
+    monkeypatch.setenv("CW_OIDC_ISSUER", "  https://auth.example.com/o/cw/  ")
+    monkeypatch.setenv("CW_OIDC_PUBLIC_BASE_URL", "https://cw.example.com/")
+    monkeypatch.setenv("CW_OIDC_GROUPS_CLAIM", "")
+    oidc = load_config()["app_auth"]["oidc"]
+    assert oidc["session_hours"] == 168
+    # Trailing slash on the issuer is significant for Authentik: keep it.
+    assert oidc["issuer"] == "https://auth.example.com/o/cw/"
+    assert oidc["public_base_url"] == "https://cw.example.com"
+    assert oidc["groups_claim"] == "groups"
+
+
+def test_env_bool_and_int_parsing(config_base: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from cw_platform.config_base import load_config
+
+    monkeypatch.setenv("CW_OIDC_ENABLED", "true")
+    monkeypatch.setenv("CW_OIDC_SESSION_HOURS", "8")
+    oidc = load_config()["app_auth"]["oidc"]
+    assert oidc["enabled"] is True
+    assert oidc["session_hours"] == 8
+
+
+@pytest.mark.parametrize("raw", ["admins,ops", '["admins","ops"]', "admins, ops"])
+def test_allowed_groups_accepts_csv_and_json(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    from cw_platform.config_base import load_config
+
+    monkeypatch.setenv("CW_OIDC_ALLOWED_GROUPS", raw)
+    assert load_config()["app_auth"]["oidc"]["allowed_groups"] == ["admins", "ops"]
+
+
+def test_generic_override_reaches_any_path(config_base: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from cw_platform.config_base import load_config
+
+    monkeypatch.setenv("CW_CFG__plex__server_url", "http://plex.internal:32400")
+    assert load_config()["plex"]["server_url"] == "http://plex.internal:32400"
+
+
+def test_api_key_creates_missing_section(config_base: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from cw_platform.config_base import load_config
+
+    monkeypatch.setenv("CW_API_KEY", "machine-key")
+    assert load_config()["security"]["api_key"] == "machine-key"
+
+
+def test_save_leaves_env_path_untouched_on_disk(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from cw_platform.config_base import load_config, save_config
+
+    _write_cfg(config_base, {"app_auth": {"oidc": {"issuer": "https://from-file.example.com/"}}})
+    monkeypatch.setenv("CW_OIDC_ISSUER", "https://from-env.example.com/")
+    save_config(load_config())
+    assert _raw_cfg(config_base)["app_auth"]["oidc"]["issuer"] == "https://from-file.example.com/"
+
+
+def test_save_omits_env_path_absent_from_disk(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from cw_platform.config_base import load_config, save_config
+
+    monkeypatch.setenv("CW_API_KEY", "machine-key")
+    save_config(load_config())
+    assert "api_key" not in _raw_cfg(config_base).get("security", {})
+
+
+def test_save_never_persists_env_secret(config_base: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from cw_platform.config_base import load_config, save_config
+
+    monkeypatch.setenv("CW_OIDC_CLIENT_SECRET", "super-secret")
+    save_config(load_config())
+    assert "super-secret" not in (config_base / "config.json").read_text(encoding="utf-8")
+    assert "client_secret" not in _raw_cfg(config_base).get("app_auth", {}).get("oidc", {})
+
+
+def test_encrypted_file_secret_survives_save_under_env_lock(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from cw_platform.config_base import load_config, save_config
+
+    _write_cfg(config_base, {"app_auth": {"oidc": {"client_secret": "file-secret"}}})
+    save_config(load_config())
+    stored = _raw_cfg(config_base)["app_auth"]["oidc"]["client_secret"]
+
+    monkeypatch.setenv("CW_OIDC_CLIENT_SECRET", "env-secret")
+    save_config(load_config())
+    after = _raw_cfg(config_base)["app_auth"]["oidc"]["client_secret"]
+    assert after == stored
+    assert "env-secret" not in (config_base / "config.json").read_text(encoding="utf-8")
+
+
+def test_unsetting_env_restores_file_value(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from cw_platform.config_base import load_config, save_config
+
+    _write_cfg(config_base, {"app_auth": {"oidc": {"issuer": "https://from-file.example.com/"}}})
+    monkeypatch.setenv("CW_OIDC_ISSUER", "https://from-env.example.com/")
+    save_config(load_config())
+
+    monkeypatch.delenv("CW_OIDC_ISSUER")
+    assert load_config()["app_auth"]["oidc"]["issuer"] == "https://from-file.example.com/"
+
+
+def test_save_does_not_mutate_callers_config(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The revert must not reach back into the dict the caller still holds."""
+    from cw_platform.config_base import load_config, save_config
+
+    monkeypatch.setenv("CW_OIDC_ISSUER", "https://from-env.example.com/")
+    cfg = load_config()
+    save_config(cfg)
+    assert cfg["app_auth"]["oidc"]["issuer"] == "https://from-env.example.com/"
+
+
+def test_save_strips_env_locked_marker(config_base: Path) -> None:
+    from cw_platform.config_base import load_config, save_config
+
+    cfg = load_config()
+    cfg["_env_locked"] = ["app_auth.oidc.issuer"]
+    save_config(cfg)
+    assert "_env_locked" not in _raw_cfg(config_base)

--- a/tests/test_env_lock_coverage.py
+++ b/tests/test_env_lock_coverage.py
@@ -1,0 +1,84 @@
+"""Every config-bound form element must be lockable, or explicitly excused.
+
+The lock is driven by data-cfg-path on the element itself. A field that ships
+without one is silently unlockable: the server still discards an env-owned
+edit, but the UI gives no sign of it.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+EXCLUSIONS_FILE = ROOT / "tests" / "data" / "env_lock_exclusions.txt"
+
+SCANNED = [
+    "ui_frontend.py",
+    "assets/js/modals/tls/index.js",
+    "assets/js/playback_progress.js",
+    *sorted(p.relative_to(ROOT).as_posix() for p in (ROOT / "providers" / "auth").glob("_auth_*.py")),
+]
+
+ELEMENT = re.compile(r"<(?:input|select|textarea)\b[^>]*")
+ELEMENT_ID = re.compile(r'id="([A-Za-z0-9_.:-]+)"')
+NO_ID = "(no id)"
+
+
+def _exclusions() -> set[str]:
+    lines = EXCLUSIONS_FILE.read_text(encoding="utf-8").splitlines()
+    return {s for s in (line.strip() for line in lines) if s and not s.startswith("#")}
+
+
+def _unannotated(rel: str) -> set[str]:
+    text = (ROOT / rel).read_text(encoding="utf-8")
+    found: set[str] = set()
+    for match in ELEMENT.finditer(text):
+        tag = match.group(0)
+        if "data-cfg-path" in tag:
+            continue
+        elem_id = ELEMENT_ID.search(tag)
+        found.add(f"{rel}:{elem_id.group(1) if elem_id else NO_ID}")
+    return found
+
+
+@pytest.mark.parametrize("rel", SCANNED)
+def test_every_form_element_is_annotated_or_excluded(rel: str) -> None:
+    missing = _unannotated(rel) - _exclusions()
+    assert not missing, (
+        "add data-cfg-path to these, or list them in "
+        f"{EXCLUSIONS_FILE.relative_to(ROOT)} with a reason: {sorted(missing)}"
+    )
+
+
+def test_exclusions_file_has_no_stale_entries() -> None:
+    """A stale exclusion hides a field that later became config-bound."""
+    live = set().union(*(_unannotated(rel) for rel in SCANNED))
+    stale = _exclusions() - live
+    assert not stale, f"exclusions no longer match any element: {sorted(stale)}"
+
+
+def test_annotated_paths_are_dotted_config_paths() -> None:
+    bad: list[str] = []
+    for rel in SCANNED:
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for path in re.findall(r'data-cfg-path="([^"]*)"', text):
+            if not path or not re.fullmatch(r"[a-z0-9_]+(\.[a-z0-9_]+)+", path):
+                bad.append(f"{rel}: {path!r}")
+    assert not bad, f"malformed data-cfg-path values: {bad}"
+
+
+def test_instance_root_matches_its_path_prefix() -> None:
+    """A mismatched root would resolve to a path no lock can ever match."""
+    bad: list[str] = []
+    for rel in SCANNED:
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for tag in ELEMENT.finditer(text):
+            root = re.search(r'data-cfg-instance-root="([^"]*)"', tag.group(0))
+            if not root:
+                continue
+            path = re.search(r'data-cfg-path="([^"]*)"', tag.group(0))
+            if not path or not path.group(1).startswith(root.group(1) + "."):
+                bad.append(f"{rel}: {tag.group(0)[:80]}")
+    assert not bad, f"instance root does not prefix its path: {bad}"

--- a/tests/test_env_lock_js.py
+++ b/tests/test_env_lock_js.py
@@ -1,0 +1,93 @@
+"""Exercises assets/helpers/env-lock.js under node with a stub DOM.
+
+The path resolution it does -- especially rewriting a provider path under the
+selected instance -- has no other coverage, and a wrong result fails open: the
+field looks editable and the save silently reverts.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "tests" / "data" / "env_lock_harness.js"
+SOURCE = ROOT / "assets" / "helpers" / "env-lock.js"
+
+pytestmark = pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+
+
+def _run(elements: list[dict], locked: list[str], instances: dict[str, str] | None = None) -> dict:
+    spec = {
+        "source": str(SOURCE),
+        "elements": elements,
+        "locked": locked,
+        "instances": instances or {},
+    }
+    proc = subprocess.run(
+        ["node", str(HARNESS), json.dumps(spec)],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=ROOT,
+    )
+    return {row["id"]: row for row in json.loads(proc.stdout)}
+
+
+def _field(elem_id: str, path: str, instance_root: str | None = None) -> dict:
+    attrs = {"data-cfg-path": path}
+    if instance_root:
+        attrs["data-cfg-instance-root"] = instance_root
+    return {"id": elem_id, "attrs": attrs}
+
+
+def test_locked_field_is_disabled_and_labelled() -> None:
+    out = _run([_field("issuer", "app_auth.oidc.issuer")], ["app_auth.oidc.issuer"])
+    assert out["issuer"]["disabled"] is True
+    assert out["issuer"]["locked"] is True
+    assert "CW_OIDC_ISSUER" in out["issuer"]["chip"]
+
+
+def test_unlocked_field_is_left_alone() -> None:
+    out = _run([_field("issuer", "app_auth.oidc.issuer")], ["security.api_key"])
+    assert out["issuer"]["disabled"] is False
+    assert out["issuer"]["chip"] is None
+
+
+def test_generic_path_names_the_cw_cfg_variable() -> None:
+    out = _run([_field("url", "plex.server_url")], ["plex.server_url"])
+    assert "CW_CFG__plex__server_url" in out["url"]["chip"]
+
+
+def test_default_instance_uses_the_bare_path() -> None:
+    out = _run(
+        [_field("url", "plex.server_url", "plex")],
+        ["plex.server_url"],
+        instances={"plex_instance": "default"},
+    )
+    assert out["url"]["disabled"] is True
+
+
+def test_named_instance_resolves_under_instances() -> None:
+    elements = [_field("url", "plex.server_url", "plex")]
+    instances = {"plex_instance": "livingroom"}
+    assert _run(elements, ["plex.instances.livingroom.server_url"], instances)["url"]["disabled"] is True
+    # The default-instance path must not lock a named instance's field.
+    assert _run(elements, ["plex.server_url"], instances)["url"]["disabled"] is False
+
+
+def test_missing_instance_selector_falls_back_to_default() -> None:
+    out = _run([_field("url", "plex.server_url", "plex")], ["plex.server_url"])
+    assert out["url"]["disabled"] is True
+
+
+def test_instance_root_that_does_not_prefix_the_path_is_ignored() -> None:
+    out = _run(
+        [_field("key", "security.api_key", "plex")],
+        ["security.api_key"],
+        instances={"plex_instance": "livingroom"},
+    )
+    assert out["key"]["disabled"] is True

--- a/tests/test_oidc_settings_ui.py
+++ b/tests/test_oidc_settings_ui.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OIDC_FIELDS = {
+    "app_auth_oidc_enabled": "app_auth.oidc.enabled",
+    "app_auth_oidc_issuer": "app_auth.oidc.issuer",
+    "app_auth_oidc_client_id": "app_auth.oidc.client_id",
+    "app_auth_oidc_client_secret": "app_auth.oidc.client_secret",
+    "app_auth_oidc_public_base_url": "app_auth.oidc.public_base_url",
+    "app_auth_oidc_groups_claim": "app_auth.oidc.groups_claim",
+    "app_auth_oidc_allowed_groups": "app_auth.oidc.allowed_groups",
+    "app_auth_oidc_session_hours": "app_auth.oidc.session_hours",
+    "security_api_key": "security.api_key",
+}
+
+
+@pytest.fixture(scope="module")
+def index_html() -> str:
+    from ui_frontend import get_index_html
+
+    return get_index_html()
+
+
+@pytest.mark.parametrize(("elem_id", "cfg_path"), sorted(OIDC_FIELDS.items()))
+def test_oidc_field_is_rendered_and_annotated(index_html: str, elem_id: str, cfg_path: str) -> None:
+    match = re.search(rf'id="{re.escape(elem_id)}"[^>]*', index_html)
+    assert match, f"{elem_id} is missing from the settings markup"
+    assert f'data-cfg-path="{cfg_path}"' in match.group(0)
+
+
+def test_oidc_secrets_are_password_inputs(index_html: str) -> None:
+    for elem_id in ("app_auth_oidc_client_secret", "security_api_key"):
+        match = re.search(rf'id="{re.escape(elem_id)}"[^>]*', index_html)
+        assert match and 'type="password"' in match.group(0)
+
+
+def test_empty_allowed_groups_denial_is_stated(index_html: str) -> None:
+    """The one setting whose empty value denies rather than defaults."""
+    assert "denies every OIDC login" in index_html
+
+
+def test_save_treats_oidc_secrets_as_masked_fields() -> None:
+    save_js = (ROOT / "assets" / "helpers" / "settings-save.js").read_text(encoding="utf-8")
+    secret_ids = save_js.split("const _cwSecretIds = [", 1)[1].split("]", 1)[0]
+    assert "app_auth_oidc_client_secret" in secret_ids
+    assert "security_api_key" in secret_ids
+
+
+def test_save_collects_every_oidc_field() -> None:
+    save_js = (ROOT / "assets" / "helpers" / "settings-save.js").read_text(encoding="utf-8")
+    for elem_id in OIDC_FIELDS:
+        assert elem_id in save_js, f"{elem_id} is rendered but never collected on save"
+
+
+def test_hydration_reads_every_oidc_field() -> None:
+    ui_js = (ROOT / "assets" / "helpers" / "settings-ui.js").read_text(encoding="utf-8")
+    for elem_id in OIDC_FIELDS:
+        assert elem_id in ui_js, f"{elem_id} is rendered but never hydrated"

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -1118,6 +1118,88 @@ def _get_index_html_static() -> str:
                       </div>
                     </div>
 
+                    <div class="cw-settings-block cw-app-card" id="app_auth_oidc_fields">
+                      <div class="cw-app-card-head">
+                        <span class="material-symbols-rounded cw-app-card-icon" aria-hidden="true">key</span>
+                        <div>
+                          <div class="cw-settings-block-title">Single sign-on (OIDC)</div>
+                          <div class="sub">Adds an identity provider such as Authentik to the login screen. The local password stays available as break-glass access.</div>
+                        </div>
+                      </div>
+                      <div class="cw-settings-2col">
+                        <div>
+                          <div class="cw-field-label-row">
+                            <label for="app_auth_oidc_enabled">Enable OIDC</label>
+                            <button type="button" class="cw-field-help material-symbols-rounded" title="Enable OIDC: Offers single sign-on on the login screen once the issuer, client, and public base URL are set." aria-label="Enable OIDC help">help</button>
+                          </div>
+                          <select id="app_auth_oidc_enabled" data-cfg-path="app_auth.oidc.enabled" name="app_auth_oidc_enabled">
+                            <option value="false">Disabled</option>
+                            <option value="true">Enabled</option>
+                          </select>
+                        </div>
+                        <div>
+                          <div class="cw-field-label-row">
+                            <label for="app_auth_oidc_issuer">Issuer URL</label>
+                            <button type="button" class="cw-field-help material-symbols-rounded" title="Issuer URL: The provider's issuer, used to fetch its discovery document. Must match the issuer in that document exactly, trailing slash included." aria-label="Issuer URL help">help</button>
+                          </div>
+                          <input id="app_auth_oidc_issuer" data-cfg-path="app_auth.oidc.issuer" name="app_auth_oidc_issuer" type="text" placeholder="https://auth.example.com/application/o/crosswatch/">
+                          <div class="sub" style="margin-top:0.35rem">A trailing slash is significant. Copy it exactly as the provider shows it.</div>
+                        </div>
+                        <div>
+                          <div class="cw-field-label-row">
+                            <label for="app_auth_oidc_client_id">Client ID</label>
+                            <button type="button" class="cw-field-help material-symbols-rounded" title="Client ID: The application identifier issued by the provider." aria-label="Client ID help">help</button>
+                          </div>
+                          <input id="app_auth_oidc_client_id" data-cfg-path="app_auth.oidc.client_id" name="app_auth_oidc_client_id" type="text" autocomplete="off">
+                        </div>
+                        <div>
+                          <div class="cw-field-label-row">
+                            <label for="app_auth_oidc_client_secret">Client secret</label>
+                            <button type="button" class="cw-field-help material-symbols-rounded" title="Client secret: The application secret issued by the provider. Leave it untouched to keep the stored value." aria-label="Client secret help">help</button>
+                          </div>
+                          <input id="app_auth_oidc_client_secret" data-cfg-path="app_auth.oidc.client_secret" name="app_auth_oidc_client_secret" type="password" autocomplete="new-password">
+                        </div>
+                        <div>
+                          <div class="cw-field-label-row">
+                            <label for="app_auth_oidc_public_base_url">Public base URL</label>
+                            <button type="button" class="cw-field-help material-symbols-rounded" title="Public base URL: The external address of this CrossWatch instance. The redirect URI registered with the provider is this URL plus /api/app-auth/oidc/callback." aria-label="Public base URL help">help</button>
+                          </div>
+                          <input id="app_auth_oidc_public_base_url" data-cfg-path="app_auth.oidc.public_base_url" name="app_auth_oidc_public_base_url" type="text" placeholder="https://crosswatch.example.com">
+                          <div class="sub" style="margin-top:0.35rem">Register <code>&lt;this URL&gt;/api/app-auth/oidc/callback</code> as the redirect URI.</div>
+                        </div>
+                        <div>
+                          <div class="cw-field-label-row">
+                            <label for="app_auth_oidc_groups_claim">Groups claim</label>
+                            <button type="button" class="cw-field-help material-symbols-rounded" title="Groups claim: The ID token claim that carries the user's group memberships." aria-label="Groups claim help">help</button>
+                          </div>
+                          <input id="app_auth_oidc_groups_claim" data-cfg-path="app_auth.oidc.groups_claim" name="app_auth_oidc_groups_claim" type="text" placeholder="groups">
+                        </div>
+                        <div>
+                          <div class="cw-field-label-row">
+                            <label for="app_auth_oidc_allowed_groups">Allowed groups</label>
+                            <button type="button" class="cw-field-help material-symbols-rounded" title="Allowed groups: Only accounts in one of these groups may sign in. Leaving it empty denies every OIDC login." aria-label="Allowed groups help">help</button>
+                          </div>
+                          <input id="app_auth_oidc_allowed_groups" data-cfg-path="app_auth.oidc.allowed_groups" name="app_auth_oidc_allowed_groups" type="text" placeholder="crosswatch-admins, crosswatch-users">
+                          <div class="sub" style="margin-top:0.35rem">Comma-separated. Leaving this empty denies every OIDC login.</div>
+                        </div>
+                        <div>
+                          <div class="cw-field-label-row">
+                            <label for="app_auth_oidc_session_hours">Session length (hours)</label>
+                            <button type="button" class="cw-field-help material-symbols-rounded" title="Session length: How long a session minted by an OIDC login stays valid, between 1 and 168 hours." aria-label="Session length help">help</button>
+                          </div>
+                          <input id="app_auth_oidc_session_hours" data-cfg-path="app_auth.oidc.session_hours" name="app_auth_oidc_session_hours" type="number" min="1" max="168" step="1" placeholder="12">
+                        </div>
+                        <div>
+                          <div class="cw-field-label-row">
+                            <label for="security_api_key">API key</label>
+                            <button type="button" class="cw-field-help material-symbols-rounded" title="API key: A static key accepted in the X-API-Key header for machine access. Leave it blank to disable machine access." aria-label="API key help">help</button>
+                          </div>
+                          <input id="security_api_key" data-cfg-path="security.api_key" name="security_api_key" type="password" autocomplete="new-password">
+                          <div class="sub" style="margin-top:0.35rem">Sent as <code>X-API-Key</code>. Blank disables key access.</div>
+                        </div>
+                      </div>
+                    </div>
+
                     <div class="cw-settings-block cw-app-card">
                       <div class="cw-app-card-head">
                         <span class="material-symbols-rounded cw-app-card-icon" aria-hidden="true">admin_panel_settings</span>

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -87,7 +87,7 @@ def register_ui_root(app: FastAPI) -> None:
 
 _HELPER_SCRIPTS = (
     "help-links.js", "provider-meta.js", "icon-select.js", "profile-select.js", "page-loader.js", "dom.js", "events.js", "api.js", "core.js", "details-log.js",
-    "media-meta.js", "trailer.js", "playing-card.js", "watchlist-preview.js", "providers-ui.js", "settings-ui.js", "settings-save.js", "maintenance.js", "backups.js",
+    "media-meta.js", "trailer.js", "playing-card.js", "watchlist-preview.js", "providers-ui.js", "env-lock.js", "settings-ui.js", "settings-save.js", "maintenance.js", "backups.js",
     "restart_apply.js",
 )
 _APP_SCRIPTS = (
@@ -773,12 +773,12 @@ def _get_index_html_static() -> str:
               <div id="sched-provider-panel" class="cw-panel hidden"></div>
               <div id="sched-provider-raw" class="hidden">
                 <div class="grid2">
-                  <div><label for="schEnabled">Enable</label><select id="schEnabled" name="schEnabled"><option value="false">Disabled</option><option value="true">Enabled</option></select></div>
-                  <div><label for="schMode">Frequency</label><select id="schMode" name="schMode"><option value="hourly">Every hour</option><option value="every_n_hours">Every N hours</option><option value="daily_time">Daily at...</option><option value="custom_interval">Custom</option></select></div>
-                  <div><label for="schN">Every N hours</label><input id="schN" name="schN" type="number" min="2" value="12"></div>
-                  <div><label for="schTime">Time</label><input id="schTime" name="schTime" type="time" value="03:30"></div>
-                  <div><label for="schCustomValue">Custom interval</label><input id="schCustomValue" name="schCustomValue" type="number" min="15" step="15" value="60"></div>
-                  <div><label for="schCustomUnit">Custom unit</label><select id="schCustomUnit" name="schCustomUnit"><option value="minutes">Minutes</option><option value="hours">Hours</option></select></div>
+                  <div><label for="schEnabled">Enable</label><select id="schEnabled" data-cfg-path="scheduling.enabled" name="schEnabled"><option value="false">Disabled</option><option value="true">Enabled</option></select></div>
+                  <div><label for="schMode">Frequency</label><select id="schMode" data-cfg-path="scheduling.mode" name="schMode"><option value="hourly">Every hour</option><option value="every_n_hours">Every N hours</option><option value="daily_time">Daily at...</option><option value="custom_interval">Custom</option></select></div>
+                  <div><label for="schN">Every N hours</label><input id="schN" data-cfg-path="scheduling.every_n_hours" name="schN" type="number" min="2" value="12"></div>
+                  <div><label for="schTime">Time</label><input id="schTime" data-cfg-path="scheduling.daily_time" name="schTime" type="time" value="03:30"></div>
+                  <div><label for="schCustomValue">Custom interval</label><input id="schCustomValue" data-cfg-path="scheduling.custom_interval_minutes" name="schCustomValue" type="number" min="15" step="15" value="60"></div>
+                  <div><label for="schCustomUnit">Custom unit</label><select id="schCustomUnit" data-cfg-path="scheduling.custom_interval_minutes" name="schCustomUnit"><option value="minutes">Minutes</option><option value="hours">Hours</option></select></div>
                 </div>
                 <div id="sched_advanced_mount"></div>
               </div>
@@ -858,7 +858,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_show_watchlist_preview">Watchlist widget</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Watchlist widget: Shows or hides the dashboard Watchlist card on the Main screen." aria-label="Watchlist widget setting help">help</button>
                           </div>
-                          <select id="ui_show_watchlist_preview" name="ui_show_watchlist_preview">
+                          <select id="ui_show_watchlist_preview" data-cfg-path="ui.show_watchlist_preview" name="ui_show_watchlist_preview">
                             <option value="true">Show</option>
                             <option value="false">Hide</option>
                           </select>
@@ -869,7 +869,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_show_recent_history_widget">Recent history widget</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Recent history widget: Shows or hides the Main screen media history widget below Watchlist." aria-label="Recent history widget setting help">help</button>
                           </div>
-                          <select id="ui_show_recent_history_widget" name="ui_show_recent_history_widget">
+                          <select id="ui_show_recent_history_widget" data-cfg-path="ui.show_recent_history_widget" name="ui_show_recent_history_widget">
                             <option value="true">Show</option>
                             <option value="false">Hide</option>
                           </select>
@@ -880,7 +880,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_show_latest_ratings_widget">Latest ratings widget</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Latest ratings widget: Shows or hides the Main screen latest ratings poster widget below Watchlist." aria-label="Latest ratings widget setting help">help</button>
                           </div>
-                          <select id="ui_show_latest_ratings_widget" name="ui_show_latest_ratings_widget">
+                          <select id="ui_show_latest_ratings_widget" data-cfg-path="ui.show_latest_ratings_widget" name="ui_show_latest_ratings_widget">
                             <option value="true">Show</option>
                             <option value="false">Hide</option>
                           </select>
@@ -891,7 +891,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_show_recent_scrobble_widget">Recent Scrobble widget</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Recent Scrobble widget: Shows or hides the Main screen recent scrobble widget below Watchlist." aria-label="Recent Scrobble widget setting help">help</button>
                           </div>
-                          <select id="ui_show_recent_scrobble_widget" name="ui_show_recent_scrobble_widget">
+                          <select id="ui_show_recent_scrobble_widget" data-cfg-path="ui.show_recent_scrobble_widget" name="ui_show_recent_scrobble_widget">
                             <option value="true">Show</option>
                             <option value="false">Hide</option>
                           </select>
@@ -902,7 +902,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_show_recent_progress_widget">Recent Progress widget</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Recent Progress widget: Shows or hides the Main screen recent progress sync activity widget." aria-label="Recent Progress widget setting help">help</button>
                           </div>
-                          <select id="ui_show_recent_progress_widget" name="ui_show_recent_progress_widget">
+                          <select id="ui_show_recent_progress_widget" data-cfg-path="ui.show_recent_progress_widget" name="ui_show_recent_progress_widget">
                             <option value="true">Show</option>
                             <option value="false">Hide</option>
                           </select>
@@ -913,7 +913,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_show_recent_playlists_widget">Recent Playlists widget</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Recent Playlists widget: Shows or hides the Main screen recent playlist sync activity widget." aria-label="Recent Playlists widget setting help">help</button>
                           </div>
-                          <select id="ui_show_recent_playlists_widget" name="ui_show_recent_playlists_widget">
+                          <select id="ui_show_recent_playlists_widget" data-cfg-path="ui.show_recent_playlists_widget" name="ui_show_recent_playlists_widget">
                             <option value="true">Show</option>
                             <option value="false">Hide</option>
                           </select>
@@ -935,7 +935,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_show_playingcard">Playing card</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Playing card: Shows or hides the currently playing card on the Main screen." aria-label="Playing card setting help">help</button>
                           </div>
-                          <select id="ui_show_playingcard" name="ui_show_playingcard">
+                          <select id="ui_show_playingcard" data-cfg-path="ui.show_playingcard" name="ui_show_playingcard">
                             <option value="true">Show</option>
                             <option value="false">Hide</option>
                           </select>
@@ -946,7 +946,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_show_recent_activity">Recent Scrobble list</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Recent Scrobble list: Shows or hides the Main screen text list of locally recorded scrobbled movies and episodes." aria-label="Recent Scrobble list setting help">help</button>
                           </div>
-                          <select id="ui_show_recent_activity" name="ui_show_recent_activity">
+                          <select id="ui_show_recent_activity" data-cfg-path="ui.show_recent_activity" name="ui_show_recent_activity">
                             <option value="true">Show</option>
                             <option value="false">Hide</option>
                           </select>
@@ -957,7 +957,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_recent_activity_display">Recent Scrobble display</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Recent Scrobble display: Choose a fixed number of rows, or show items from the last 24, 48, or 72 hours with a maximum of 5 rows." aria-label="Recent Scrobble display setting help">help</button>
                           </div>
-                          <select id="ui_recent_activity_display" name="ui_recent_activity_display">
+                          <select id="ui_recent_activity_display" data-cfg-path="ui.recent_activity_display" name="ui_recent_activity_display">
                             <option value="count:3">Last 3 items</option>
                             <option value="count:4">Last 4 items</option>
                             <option value="count:5">Last 5 items</option>
@@ -972,7 +972,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_recent_syncs_display">Recent syncs display</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Recent syncs display: Choose a fixed number of rows, or show runs from the last 24, 48, or 72 hours with a maximum of 5 rows." aria-label="Recent syncs display setting help">help</button>
                           </div>
-                          <select id="ui_recent_syncs_display" name="ui_recent_syncs_display">
+                          <select id="ui_recent_syncs_display" data-cfg-path="ui.recent_syncs_display" name="ui_recent_syncs_display">
                             <option value="count:3">Last 3 items</option>
                             <option value="count:4">Last 4 items</option>
                             <option value="count:5">Last 5 items</option>
@@ -987,7 +987,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_show_quick_add_desktop">Desktop quick add</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Desktop quick add: Shows or hides the quick-add control on larger screens." aria-label="Desktop quick add setting help">help</button>
                           </div>
-                          <select id="ui_show_quick_add_desktop" name="ui_show_quick_add_desktop">
+                          <select id="ui_show_quick_add_desktop" data-cfg-path="ui.show_quick_add_desktop" name="ui_show_quick_add_desktop">
                             <option value="true">Show</option>
                             <option value="false">Hide</option>
                           </select>
@@ -998,7 +998,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_show_quick_add_mobile">Mobile quick add</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Mobile quick add: Shows or hides the compact quick-add control on mobile layouts." aria-label="Mobile quick add setting help">help</button>
                           </div>
-                          <select id="ui_show_quick_add_mobile" name="ui_show_quick_add_mobile">
+                          <select id="ui_show_quick_add_mobile" data-cfg-path="ui.show_quick_add_mobile" name="ui_show_quick_add_mobile">
                             <option value="true">Show</option>
                             <option value="false">Hide</option>
                           </select>
@@ -1020,7 +1020,7 @@ def _get_index_html_static() -> str:
                             <label for="ui_theme">Theme</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Theme: Choose Flat dark, Flat light Experimental, or Original to use the classic CrossWatch styling." aria-label="Theme setting help">help</button>
                           </div>
-                          <select id="ui_theme" name="ui_theme">
+                          <select id="ui_theme" data-cfg-path="ui.theme" name="ui_theme">
                             <option value="flat-dark">Flat dark</option>
                             <option value="flat-light">Flat light (Experimental)</option>
                             <option value="original">Original</option>
@@ -1032,7 +1032,7 @@ def _get_index_html_static() -> str:
                             <button type="button" class="cw-field-help material-symbols-rounded" title="UI protocol: HTTP is simplest. HTTPS serves CrossWatch with a self-signed certificate for encrypted browser traffic." aria-label="UI protocol setting help">help</button>
                           </div>
                           <div class="cw-settings-inline-action">
-                            <select id="ui_protocol" name="ui_protocol">
+                            <select id="ui_protocol" data-cfg-path="ui.protocol" name="ui_protocol">
                               <option value="http">HTTP</option>
                               <option value="https">HTTPS (self-signed)</option>
                             </select>
@@ -1064,14 +1064,14 @@ def _get_index_html_static() -> str:
                             <label for="app_auth_username">Username</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Username: The local CrossWatch username used on the login screen." aria-label="Username setting help">help</button>
                           </div>
-                          <input id="app_auth_username" name="app_auth_username" type="text" autocomplete="username" placeholder="admin">
+                          <input id="app_auth_username" data-cfg-path="app_auth.username" name="app_auth_username" type="text" autocomplete="username" placeholder="admin">
                         </div>
                         <div class="cw-auth-password-field">
                           <div class="cw-field-label-row">
                             <label for="app_auth_password">New password</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="New password: Enter a new local CrossWatch password. Leave it blank to keep the current password." aria-label="New password setting help">help</button>
                           </div>
-                          <input id="app_auth_password" name="app_auth_password" type="password" autocomplete="new-password" placeholder="(leave blank to keep)">
+                          <input id="app_auth_password" data-cfg-path="app_auth.password.hash" name="app_auth_password" type="password" autocomplete="new-password" placeholder="(leave blank to keep)">
                           <div class="sub" style="margin-top:0.35rem">Leave blank to keep the current password.</div>
                         </div>
                         <div class="cw-auth-confirm-field">
@@ -1079,7 +1079,7 @@ def _get_index_html_static() -> str:
                             <label for="app_auth_password2">Confirm password</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Confirm password: Repeat the new password exactly so CrossWatch can verify it before saving." aria-label="Confirm password setting help">help</button>
                           </div>
-                          <input id="app_auth_password2" name="app_auth_password2" type="password" autocomplete="new-password" placeholder="(repeat)">
+                          <input id="app_auth_password2" data-cfg-path="app_auth.password.hash" name="app_auth_password2" type="password" autocomplete="new-password" placeholder="(repeat)">
                           <div class="sub" style="margin-top:0.35rem">Repeat the new password exactly before saving.</div>
                         </div>
                         <div class="cw-auth-session-row">
@@ -1088,7 +1088,7 @@ def _get_index_html_static() -> str:
                               <label for="app_auth_remember_enabled">Session caching</label>
                               <button type="button" class="cw-field-help material-symbols-rounded" title="Session caching: Keeps you signed in across browser restarts. Browser session only signs out when the browser session ends." aria-label="Session caching setting help">help</button>
                             </div>
-                            <select id="app_auth_remember_enabled" name="app_auth_remember_enabled">
+                            <select id="app_auth_remember_enabled" data-cfg-path="app_auth.remember_session_enabled" name="app_auth_remember_enabled">
                               <option value="true">Enabled</option>
                               <option value="false">Browser session only</option>
                             </select>
@@ -1099,7 +1099,7 @@ def _get_index_html_static() -> str:
                               <label for="app_auth_remember_days">Session timeout</label>
                               <button type="button" class="cw-field-help material-symbols-rounded" title="Session timeout: Number of days a remembered login remains valid when session caching is enabled." aria-label="Session timeout setting help">help</button>
                             </div>
-                            <input id="app_auth_remember_days" name="app_auth_remember_days" type="text" inputmode="numeric" pattern="[0-9]{1,3}" maxlength="3" autocomplete="off" placeholder="30">
+                            <input id="app_auth_remember_days" data-cfg-path="app_auth.remember_session_days" name="app_auth_remember_days" type="text" inputmode="numeric" pattern="[0-9]{1,3}" maxlength="3" autocomplete="off" placeholder="30">
                             <div id="app_auth_remember_days_error" class="cw-field-inline-error hidden" role="alert"></div>
                             <div class="sub" style="margin-top:0.35rem">Used only when session caching is enabled. Maximum 365 days.</div>
                           </div>
@@ -1153,7 +1153,7 @@ def _get_index_html_static() -> str:
                             <label for="trusted_proxies">Trusted reverse proxies (optional)</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Trusted reverse proxies: Enter proxy IPs or CIDR ranges so CrossWatch can read the real client IP for login rate limiting." aria-label="Trusted reverse proxies setting help">help</button>
                           </div>
-                          <input id="trusted_proxies" name="trusted_proxies" type="text" placeholder="127.0.0.1;192.168.2.1;192.168.2.0/16">
+                          <input id="trusted_proxies" data-cfg-path="security.trusted_proxies" name="trusted_proxies" type="text" placeholder="127.0.0.1;192.168.2.1;192.168.2.0/16">
                           <div class="sub" style="margin-top:0.35rem">
                             Only needed when behind a reverse proxy and you want accurate IP-based login rate limiting.
                             Enter proxy IPs or CIDR ranges separated by <code>;</code>
@@ -1181,7 +1181,7 @@ def _get_index_html_static() -> str:
                             <label for="cw_enabled">Enabled</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Enabled: Turns the local tracker snapshot system on or off." aria-label="Local Tracker enabled setting help">help</button>
                           </div>
-                          <select id="cw_enabled" name="cw_enabled">
+                          <select id="cw_enabled" data-cfg-path="crosswatch.enabled" name="cw_enabled">
                             <option value="true">Enabled</option>
                             <option value="false">Disabled</option>
                           </select>
@@ -1192,7 +1192,7 @@ def _get_index_html_static() -> str:
                             <label for="cw_retention_days">Retention (days)</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Retention days: How long snapshot files are kept before cleanup. Set 0 to keep snapshots forever." aria-label="Retention days setting help">help</button>
                           </div>
-                          <input id="cw_retention_days" name="cw_retention_days" type="number" min="0" step="1" placeholder="30">
+                          <input id="cw_retention_days" data-cfg-path="crosswatch.retention_days" name="cw_retention_days" type="number" min="0" step="1" placeholder="30">
                           <div class="sub" style="margin-top:0.35rem">0 = keep snapshots forever.</div>
                         </div>
 
@@ -1201,7 +1201,7 @@ def _get_index_html_static() -> str:
                             <label for="cw_auto_snapshot">Auto snapshot</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Auto snapshot: Saves a tracker snapshot before CrossWatch writes provider changes, giving you a local restore point." aria-label="Auto snapshot setting help">help</button>
                           </div>
-                          <select id="cw_auto_snapshot" name="cw_auto_snapshot">
+                          <select id="cw_auto_snapshot" data-cfg-path="crosswatch.auto_snapshot" name="cw_auto_snapshot">
                             <option value="true">On (before writes)</option>
                             <option value="false">Off</option>
                           </select>
@@ -1212,7 +1212,7 @@ def _get_index_html_static() -> str:
                             <label for="cw_max_snapshots">Max snapshots per feature</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Max snapshots per feature: Limits how many Watchlist, Ratings, and History snapshots are kept. Set 0 for unlimited." aria-label="Max snapshots per feature setting help">help</button>
                           </div>
-                          <input id="cw_max_snapshots" name="cw_max_snapshots" type="number" min="0" step="1" placeholder="64">
+                          <input id="cw_max_snapshots" data-cfg-path="crosswatch.max_snapshots" name="cw_max_snapshots" type="number" min="0" step="1" placeholder="64">
                           <div class="sub" style="margin-top:0.35rem">0 = unlimited.</div>
                         </div>
                       </div>
@@ -1232,7 +1232,7 @@ def _get_index_html_static() -> str:
                             <label for="cw_restore_watchlist">Watchlist snapshot</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Watchlist snapshot: Select which local watchlist snapshot should be used for restore or tracker-backed reads." aria-label="Watchlist snapshot setting help">help</button>
                           </div>
-                          <select id="cw_restore_watchlist" name="cw_restore_watchlist"></select>
+                          <select id="cw_restore_watchlist" data-cfg-path="crosswatch.restore_watchlist" name="cw_restore_watchlist"></select>
                         </div>
 
                         <div>
@@ -1240,7 +1240,7 @@ def _get_index_html_static() -> str:
                             <label for="cw_restore_history">History snapshot</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="History snapshot: Select which local history snapshot should be used for restore or tracker-backed reads." aria-label="History snapshot setting help">help</button>
                           </div>
-                          <select id="cw_restore_history" name="cw_restore_history"></select>
+                          <select id="cw_restore_history" data-cfg-path="crosswatch.restore_history" name="cw_restore_history"></select>
                         </div>
 
                         <div>
@@ -1248,7 +1248,7 @@ def _get_index_html_static() -> str:
                             <label for="cw_restore_ratings">Ratings snapshot</label>
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Ratings snapshot: Select which local ratings snapshot should be used for restore or tracker-backed reads." aria-label="Ratings snapshot setting help">help</button>
                           </div>
-                          <select id="cw_restore_ratings" name="cw_restore_ratings"></select>
+                          <select id="cw_restore_ratings" data-cfg-path="crosswatch.restore_ratings" name="cw_restore_ratings"></select>
                         </div>
                       </div>
                       <div class="sub" style="margin-top:0.75rem">
@@ -1286,7 +1286,7 @@ def _get_index_html_static() -> str:
                   </div>
                   <div class="cw-maint-debug-field">
                     <label for="debug">Level</label>
-                    <select id="debug" name="debug">
+                    <select id="debug" data-cfg-path="runtime.debug" name="debug">
                       <option value="off">off</option>
                       <option value="on">on</option>
                       <option value="mods">on - including MOD debug - best option for debug</option>


### PR DESCRIPTION
Any config setting can now come from the environment, with OIDC and the static API key getting short variable names. Written by an AI agent (Claude Code) under review.

## What

Environment values win over `config.json` and are **never written back to it** — a secret from a Docker or Kubernetes Secret stays out of the config volume, and unsetting the variable reverts the field to whatever the file held.

| Variable | Setting |
| --- | --- |
| `CW_OIDC_ENABLED` / `_ISSUER` / `_CLIENT_ID` / `_CLIENT_SECRET` | OIDC provider |
| `CW_OIDC_PUBLIC_BASE_URL` / `_GROUPS_CLAIM` / `_ALLOWED_GROUPS` / `_SESSION_HOURS` | OIDC policy |
| `CW_API_KEY` | Static `X-API-Key` for machine access |
| `CW_CFG__a__b__c` | Any other config path |

Values parse as JSON when they are JSON (`true`, `12`, `["a","b"]`) and as plain text otherwise, so a URL needs no quoting. `CW_OIDC_ALLOWED_GROUPS` also accepts a comma-separated list.

## Not half-locked

An env-owned field that still looks editable is worse than no env support: the save reports success and the value reverts on reload. So:

- `GET /api/config` reports `_env_locked`; annotated inputs render disabled and labelled with the variable that owns them.
- `POST /api/config` forces locked paths back and returns `env_locked_ignored`, which the UI surfaces as a toast. This is authoritative — it covers every path whether or not the UI knows about it.
- 97 config-bound inputs across the settings pane, the twelve provider auth forms, the TLS modal, and the playback-progress timeout now carry `data-cfg-path`. Provider fields also carry `data-cfg-instance-root`, since their real path moves under `<provider>.instances.<name>` for any instance but the default.
- `test_env_lock_coverage` fails when a form element carries neither an annotation nor an entry in `tests/data/env_lock_exclusions.txt`, so an unlockable setting cannot ship by accident. It also flags stale exclusions and malformed paths.

OIDC had no UI at all, so there was nothing to lock. This adds a single sign-on card to the app_auth pane covering the eight OIDC fields plus `security.api_key`, both secrets on the existing mask convention.

## Worth a look during review

- **The revert runs on the encrypted write payload, not on the caller's config.** `save_config` only shallow-copies its argument, so reverting in place reaches into nested dicts the caller still holds — and `load_config` calls `save_config` on first run, which deleted the value it had just applied. Caught by `test_save_does_not_mutate_callers_config`.
- **Empty is an override, not an absence.** `CW_OIDC_ISSUER=` locks the field to empty. Remove the variable to hand the field back. The alternative makes it impossible to deliberately blank a field from the environment.
- **`_normalize_app_auth` now splits a bare-string `allowed_groups` on commas.** A single env var can only carry a string. Existing single-value configs are unaffected.
- **Limits, documented in the README:** list entries are unaddressable (`pairs`, scrobbler routes), as are keys starting with an underscore.

## Verified

- 1042 pass. The 6 failures on this branch are the same 6 already failing on `main`.
- End to end against a running instance: env values active in memory and absent from `config.json`; `_env_locked` reported; `CW_API_KEY` authenticates; a POST changing a locked path returns `env_locked_ignored`, keeps the env value, and still saves the unlocked field in the same payload.
- `env-lock.js` path resolution covered under node with a stub DOM.

Design doc: `docs/superpowers/specs/2026-07-31-oidc-env-vars-design.md`

https://claude.ai/code/session_01BmvnXoyDkpEfcyzZvYga5F
