### PR TITLE
chore(ci): expand action version comments to full semver

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -13,12 +13,12 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -28,7 +28,7 @@ jobs:
       # repo metadata and are passed to build-push-action as --label, which wins
       # over the Dockerfile's LABEL. Restate the fork disclaimer here so the dev
       # image cannot end up implying upstream endorsement (License Section 11).
-      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         id: meta
         with:
           images: ${{ env.IMAGE }}
@@ -40,7 +40,7 @@ jobs:
             org.opencontainers.image.description=Unofficial fork of cenodude/CrossWatch. One brain for all your media syncs, a single place to configure everything. Not endorsed by the upstream Copyright Holder.
             org.opencontainers.image.licenses=LicenseRef-CrossWatch-Source-Available-1.0
 
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
- Digest-pinned GitHub Actions had shorthand major-version comments (`# v4`)
- Resolved each pinned commit against the action's upstream tags via the GitHub API and replaced the comment with the full semver actually pinned
- No digest values changed, comment-only

## Test plan
- [ ] Confirm workflow still runs as expected (no functional change)

https://claude.ai/code/session_01LX7oidFx9YFfBoiRuUeVF5