### PR TITLE
ci: add concurrency group to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
     branches: [main, beta]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Rapid successive pushes to the same PR/branch previously queued every CI run to completion instead of canceling the stale one — unlike the other repos in the `jabrown93/ci` build/lint template. Adds the same `concurrency` block used elsewhere:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```